### PR TITLE
Add config system, CLI config command, and project guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,114 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Dev tooling
+
+Task runner is [`just`](https://just.systems); package/env manager is [`uv`](https://docs.astral.sh/uv/). One-time setup: `just setup` (installs `uv`, syncs deps, installs pre-commit). Python is pinned to `>=3.10,<3.11` in `pyproject.toml`.
+
+Common recipes (see `justfile`):
+
+```bash
+just                       # list recipes
+just format                # ruff format + ruff --fix
+just lint                  # ruff format --check, ruff check, mypy (src/tests/scripts)
+just test                  # full suite, includes slow, with coverage
+just test-fast             # unit + integration, no slow
+just test-unit             # unit only
+just test-int              # integration only
+just test-k <expr> [args]  # pytest -k <expr>
+just coverage-html         # HTML coverage on http://localhost:8000
+```
+
+To run a single test: `just test-k "test_name"` or `uv run pytest path/to/test.py::test_name`. To run a script: `uv run python scripts/<name>.py`.
+
+### Non-negotiable per-change checks
+
+- **`just lint && just test` must both pass** before declaring work done. Lint is not optional — pre-commit runs format + lint + mypy; CI runs the same plus tests on push/PR to `main`.
+- **100% coverage on every file in `src/`** must be maintained. If a touched commit drops a file below 100%, fix the gap — even in files you did not edit. Coverage omits test dirs (see `[tool.coverage.run]` in `pyproject.toml`).
+- Ruff is `select = ["ALL"]` with a small ignore list; see `[tool.ruff.lint]` for the rationale on each ignore. Per-file ignores exist for `scripts/*` (allows `print`) and `tests/**` (allows `assert`, magic numbers, private access, etc.).
+- mypy runs with `disallow_untyped_defs` and `check_untyped_defs` — type every def.
+
+### Pytest setup
+
+Markers (registered in `tests/conftest.py` and `pyproject.toml`):
+- `unit` — fast, isolated
+- `integration` — uses real models
+- `slow` — heavyweight; **excluded by default** via `addopts = ["-m", "not slow"]`. Pass `-m ""` or use `just test` to include.
+
+`pytest-randomly` randomizes order; `pytest-antilru` clears LRU caches between tests. Two warnings are filtered (protobuf gencode mismatch from TF vs. qairt-dev pin, and matplotlib pyparsing deprecation) — see `[tool.pytest.ini_options].filterwarnings`.
+
+## Architecture
+
+Data flows one direction: **Sensor → Message → Pipeline → Stages → Message out**.
+
+```
+BaseSensor.read() ─► Message ─► Pipeline.run(msg, metrics=…)
+                                  ├─► Stage[0].process(msg, metrics)
+                                  ├─► Stage[1].process(msg, metrics)
+                                  └─► Stage[N] → Message | None
+```
+
+### Core types
+
+- **`Pipeline`** (`pipeline.py`) — holds ordered `list[Stage]`. Any stage returning `None` short-circuits the rest. Wraps the whole run in a `SpanType.PIPELINE` metrics span.
+- **`Stage`** (`stages/_base.py`) — ABC. Subclasses implement `_process(msg, metrics) -> Message | None`. The base `process()` wraps `_process` in a `SpanType.STAGE` span, stamps `latency_ms` on the result via `model_copy`, and logs. Stages do **not** store their index.
+- **Messages** (`messages/`) — immutable Pydantic `BaseModel` subclasses inheriting `BaseMessage` (`timestamp`, `latency_ms`). `messages.Message` is a `TypeAlias` union of every concrete message type — use it for `isinstance` and exhaustive `match`.
+- **`MetricsCollector`** (`metrics/`) — optional; `Pipeline`/`Stage` fall back to `NullMetricsCollector` when none is passed, so stage code never null-checks. Public types come from `_types.py` (`Span`, `SpanType`, `Trace`, `MetricsReport`); collector logic lives in `_collector.py`.
+- **`ComputeBackend`** (`hardware/`) — the *only* allowed entry point to inference runtimes. Detects platform at construction, picks an `InferenceBackend` subclass under `hardware/_platforms/<chip>/`. Model handles are opaque `object`s. **Nothing outside `hardware/` may import LiteRT / ONNX / SNPE directly.**
+- **`ModelManager`** + `MODEL_REGISTRY` (`models/`) — resolves model IDs to download sources (`HuggingFaceSource`, `VendoredSource`) and writes them into the model cache.
+- **`PathManager`** (`paths/`) — only legitimate way to get filesystem paths. Wraps `platformdirs` versioned dirs. `path_mgr.cache` → `CacheManager` (+ `models` submanager); `path_mgr.data` → `DataManager`; `path_mgr.logs_dir`; `path_mgr.app_config_file`. **Do not create app data directories manually.** See `docs/paths.md`.
+- **`AppConfig`** (`config.py`) — pydantic model persisted as JSON at `path_mgr.app_config_file`. `load_config()` writes defaults on first run and re-normalizes on every load.
+
+### CLI
+
+Entry point `m2a` (`pyproject.toml` `[project.scripts]`) → `moment_to_action._cli:cli`.
+
+- Built on `rich_click` with a custom **`AutoRichGroup`** (`_cli/_auto_group.py`) that auto-loads subcommands by globbing `cmd_*` files/dirs and importing the matching object (e.g. `cmd_config.py` must export `config`).
+- Root callback in `_cli/__init__.py` constructs `PathManager`, loads `AppConfig`, inits logging, and stashes a `GlobalData(log, path_manager, config)` on `ctx.obj`. Subcommands retrieve it via `pass_global_data` or `get_global_data(ctx)`.
+- New CLI commands: drop a `cmd_<name>.py` (or `cmd_<name>/` package) under `src/moment_to_action/_cli/commands/` exporting `<name>` as a `click.Command`/`Group`. No manual registration needed.
+
+### Stages, by category
+
+- `stages.video` — `PreprocessorStage`, `YOLOStage`, `ClipBufferStage`
+- `stages.vlm` — `MobileCLIPStage`, `SmolVLM2Stage`
+- `stages.llm` — `ReasoningStage`
+- `stages.audio` — placeholder
+- `stages/_preprocess.py` — generic `BasePreprocessor[InputT, OutputT]`. Subclasses call `self._dispatch(fn, *args)` (not `fn(*args)`) so DSP/CPU routing works when a Hexagon backend lands.
+
+## Conventions
+
+### Style
+- `from __future__ import annotations` at the top of every file.
+- Line length 100. Google-style docstrings (`[tool.ruff.lint.pydocstyle].convention = "google"`).
+- Use `object` instead of `Any` except where a runtime handle is genuinely opaque (`_ModelHandle.raw` is the one sanctioned `Any`).
+- Type-checker-only imports go under `if TYPE_CHECKING:`.
+
+### Data classes
+- **`@attrs.define`** — mutable, slotted (replaces `@dataclass(slots=True)`).
+- **`@attrs.frozen`** — immutable, slotted (replaces `@dataclass(frozen=True, slots=True)`).
+- `attrs.Factory(dict)` instead of `field(default_factory=dict)`. Serialize with `attrs.asdict`.
+- Pydantic `BaseModel` is reserved for **pipeline messages**, not config-internal types or metrics types.
+
+### File layout
+- `_base.py` — abstract base for a subsystem.
+- `_types.py` — pure data types / enums for a subsystem (no logic).
+- `__init__.py` — re-exports the public API; private helpers stay `_`-prefixed.
+- Platform-specific code lives under `hardware/_platforms/<chip>/`.
+
+### Avoiding circular imports
+Import from `_types.py` submodules instead of from the top-level subpackage when wiring cross-module types.
+
+## Docs
+
+In-repo design docs live in `docs/`. Consult before touching the relevant subsystem and keep them in sync when behavior changes.
+
+- [`docs/paths.md`](docs/paths.md) — `PathManager` / `CacheManager` / `DataManager` contract and platform-specific directory layout. Required reading before adding any filesystem path.
+
+## Contributing flow
+
+1. Branch off `main` as `<your_name>/<feature>` (e.g. `nikola/add-logging`).
+2. Write code **and tests**; keep coverage at 100%.
+3. `just lint && just test` clean locally.
+4. Open PR to `main` using `.github/pull_request_template.md`; GitHub Actions runs lint + tests.
+5. Merge as a **squash commit**.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,8 +185,6 @@ omit = [
     "*/tests/*",
     "*/__pycache__/*",
     "*/site-packages/*",
-    "*/__init__.py",
-    "*/edgeperceive/*",
 ]
 relative_files = true
 

--- a/src/moment_to_action/_cli/__init__.py
+++ b/src/moment_to_action/_cli/__init__.py
@@ -4,6 +4,8 @@ from pathlib import Path
 import rich_click as click
 
 from moment_to_action._logging import init_logging
+from moment_to_action.config import load_config
+from moment_to_action.paths import PathManager
 from moment_to_action.utils.cli import GlobalData, ctx_get_seed, ctx_set_seed
 
 from ._auto_group import auto_group
@@ -16,7 +18,7 @@ from ._params import BASED_INT
     "--verbose",
     default=False,
     is_flag=True,
-    help="Enable verbose logging.",
+    help="Enable verbose logging (overrides config log_level).",
 )
 @click.option(
     "-s",
@@ -29,12 +31,16 @@ from ._params import BASED_INT
 @click.pass_context
 def cli(ctx: click.Context, *, verbose: bool, seed: int | None) -> None:
     """MTJ array simulation tool."""
-    # Initialize logging
-    init_logging(verbose=verbose)
+    # Load config first so log_level is available
+    path_manager = PathManager()
+    config = load_config(path_manager.app_config_file)
+
+    # Init logging
+    init_logging(log_level="DEBUG" if verbose else config.log_level)
     log = logging.getLogger("moment_to_action.cli")
 
-    # Set global context data
-    ctx.obj = GlobalData(log=log)
+    # Build global data object
+    ctx.obj = GlobalData(log=log, path_manager=path_manager, config=config)
 
     # Set seed
     ctx_set_seed(ctx, seed)

--- a/src/moment_to_action/_cli/commands/cmd_cache/cmd_clear.py
+++ b/src/moment_to_action/_cli/commands/cmd_cache/cmd_clear.py
@@ -7,7 +7,7 @@ import json
 import rich_click as click
 from rich.console import Console
 
-from moment_to_action.paths import PathManager
+from moment_to_action.utils.cli import GlobalData, pass_global_data
 
 
 @click.command()
@@ -17,8 +17,8 @@ from moment_to_action.paths import PathManager
     is_flag=True,
     help="Skip confirmation prompt and clear cache immediately.",
 )
-@click.pass_context
-def clear(ctx: click.Context, *, json_output: bool, force: bool) -> None:
+@pass_global_data
+def clear(data: GlobalData, *, json_output: bool, force: bool) -> None:
     """Clear the application cache.
 
     Removes everything in the cache directory (cached models and any other
@@ -29,8 +29,6 @@ def clear(ctx: click.Context, *, json_output: bool, force: bool) -> None:
 
     Use --json to get machine-readable output in JSON format.
     """
-    path_manager = PathManager()
-
     if not json_output and not force:
         console = Console()
         try:
@@ -39,11 +37,11 @@ def clear(ctx: click.Context, *, json_output: bool, force: bool) -> None:
             )
             if confirmed.lower() not in ("y", "yes"):
                 console.print("[cyan]Cache clear cancelled.[/cyan]")
-                ctx.exit(0)
+                return
         except EOFError:
             pass
 
-    info = path_manager.cache.clear_cache()
+    info = data.path_manager.cache.clear_cache()
 
     if json_output:
         click.echo(json.dumps(info.to_json(), indent=2))

--- a/src/moment_to_action/_cli/commands/cmd_cache/cmd_inspect.py
+++ b/src/moment_to_action/_cli/commands/cmd_cache/cmd_inspect.py
@@ -7,19 +7,19 @@ import json
 import rich_click as click
 from rich.console import Console
 
-from moment_to_action.paths import PathManager
+from moment_to_action.utils.cli import GlobalData, pass_global_data
 
 
 @click.command()
 @click.option("--json", "json_output", is_flag=True, help="Output as JSON.")
-def inspect(*, json_output: bool) -> None:
+@pass_global_data
+def inspect(data: GlobalData, *, json_output: bool) -> None:
     """Inspect the application cache.
 
     Displays a summary of the cache contents (size, sub-caches, unexpected
     files). Use --json to get machine-readable output in JSON format.
     """
-    path_manager = PathManager()
-    info = path_manager.cache.inspect_cache()
+    info = data.path_manager.cache.inspect_cache()
 
     if json_output:
         click.echo(json.dumps(info.to_json(), indent=2))

--- a/src/moment_to_action/_cli/commands/cmd_config.py
+++ b/src/moment_to_action/_cli/commands/cmd_config.py
@@ -1,0 +1,60 @@
+"""Config command — get/set application configuration values."""
+
+from __future__ import annotations
+
+import rich_click as click
+from pydantic import ValidationError
+from rich.console import Console
+from rich.table import Table
+
+from moment_to_action.config import AppConfig, save_config
+from moment_to_action.utils.cli import GlobalData, pass_global_data
+
+
+@click.command()
+@click.argument("key", required=False)
+@click.argument("value", required=False)
+@click.option("--json", "json_output", is_flag=True, help="Output as JSON.")
+@pass_global_data
+def config(data: GlobalData, key: str | None, value: str | None, *, json_output: bool) -> None:
+    r"""Get or set a configuration value.
+
+    With no arguments, prints the full config. With KEY only, prints the
+    current value. With KEY and VALUE, sets the value.
+
+    \b
+    Examples:
+      m2a config
+      m2a config max_workers
+      m2a config max_workers 8
+    """
+    cfg = data.config
+
+    if key is None:
+        if json_output:
+            click.echo(cfg.model_dump_json(indent=2))
+            return
+        table = Table(title="Config")
+        table.add_column("Key")
+        table.add_column("Value")
+        for k, v in cfg.model_dump().items():
+            table.add_row(k, str(v))
+        Console().print(table)
+        return
+
+    if key not in AppConfig.model_fields:
+        msg = f"Unknown key '{key}'. Valid keys: {', '.join(AppConfig.model_fields)}"
+        raise click.BadParameter(msg)
+
+    if value is None:
+        click.echo(getattr(cfg, key))
+        return
+
+    try:
+        updated = AppConfig.model_validate({**cfg.model_dump(), key: value})
+    except ValidationError as e:
+        raise click.BadParameter(str(e)) from e
+
+    save_config(updated, data.path_manager.app_config_file)
+    data.config = updated
+    click.echo(f"{key} = {getattr(updated, key)}")

--- a/src/moment_to_action/_logging.py
+++ b/src/moment_to_action/_logging.py
@@ -8,15 +8,15 @@ from rich.logging import RichHandler
 _stderr_console = Console(stderr=True)
 
 
-def init_logging(*, verbose: bool) -> None:
+def init_logging(*, log_level: str) -> None:
     """Initialize logging.
 
     Args:
-        verbose:
-            Should verbose messages be printed?
+        log_level:
+            Logging level name (e.g. ``"DEBUG"``, ``"INFO"``).
     """
     logging.basicConfig(
-        level=logging.DEBUG if verbose else logging.INFO,
+        level=getattr(logging, log_level),
         format="%(message)s",
         datefmt="[%X]",
         handlers=[

--- a/src/moment_to_action/config.py
+++ b/src/moment_to_action/config.py
@@ -1,0 +1,35 @@
+"""Application configuration model and persistence."""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Literal
+
+from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class AppConfig(BaseModel):
+    """Application configuration."""
+
+    max_workers: int = Field(default_factory=lambda: os.cpu_count() or 1, ge=1)
+    log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = "INFO"
+
+
+def load_config(path: Path) -> AppConfig:
+    """Load config from path, writing defaults if the file does not exist."""
+    if not path.exists():
+        config = AppConfig()
+        save_config(config, path)
+        return config
+    config = AppConfig.model_validate_json(path.read_text())
+    save_config(config, path)  # normalize to standard format
+    return config
+
+
+def save_config(config: AppConfig, path: Path) -> None:
+    """Save config to path, creating parent directories as needed."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(config.model_dump_json(indent=2))

--- a/src/moment_to_action/stages/_preprocess.py
+++ b/src/moment_to_action/stages/_preprocess.py
@@ -30,7 +30,6 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
-from collections.abc import Callable  # noqa: TC003
 from typing import TYPE_CHECKING, Generic, ParamSpec, TypeVar
 
 from moment_to_action.hardware import ComputeUnit
@@ -39,6 +38,8 @@ from moment_to_action.metrics._types import SpanType
 from moment_to_action.utils import BufferPool, ComputeDispatcher
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from moment_to_action.metrics._collector import MetricsCollector
 
 logger = logging.getLogger(__name__)

--- a/src/moment_to_action/utils/cli.py
+++ b/src/moment_to_action/utils/cli.py
@@ -6,11 +6,13 @@ import secrets
 from typing import TYPE_CHECKING
 
 import attrs
+import rich_click as click
 
 if TYPE_CHECKING:
     import logging
 
-    import rich_click as click
+    from moment_to_action.config import AppConfig
+    from moment_to_action.paths import PathManager
 
 _SEED_KEY = "moment_to_action.seed"
 
@@ -21,6 +23,16 @@ class GlobalData:
 
     log: logging.Logger
     """CLI logger."""
+
+    path_manager: PathManager
+    """Application path manager."""
+
+    config: AppConfig
+    """Application configuration."""
+
+
+pass_global_data = click.make_pass_decorator(GlobalData)
+"""Decorator that passes the GlobalData instance from the click context."""
 
 
 def get_global_data(ctx: click.Context) -> GlobalData:

--- a/src/moment_to_action/utils/compute.py
+++ b/src/moment_to_action/utils/compute.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable  # noqa: TC003
-from typing import ParamSpec, TypeVar
+from typing import TYPE_CHECKING, ParamSpec, TypeVar
 
 from moment_to_action.hardware import ComputeUnit
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 logger = logging.getLogger(__name__)
 

--- a/tests/unit/cli/commands/cache/test_cmd_cache_clear.py
+++ b/tests/unit/cli/commands/cache/test_cmd_cache_clear.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from click.testing import CliRunner
 
-from moment_to_action._cli.commands.cmd_cache.cmd_clear import clear
+from moment_to_action.config import AppConfig
 from moment_to_action.paths._cache._manager import CacheInfo
 from moment_to_action.paths._cache._models import ModelCacheContents
 
@@ -48,10 +48,11 @@ class TestCacheClearCommand:
 
         with patch("moment_to_action._cli.init_logging"):
             with patch(
-                "moment_to_action._cli.commands.cmd_cache.cmd_clear.PathManager",
+                "moment_to_action._cli.PathManager",
                 return_value=_patched_path_manager(_make_cache_info(0)),
             ):
-                result = CliRunner().invoke(cli, ["cache", "clear", "--force"])
+                with patch("moment_to_action._cli.load_config", return_value=AppConfig()):
+                    result = CliRunner().invoke(cli, ["cache", "clear", "--force"])
 
         assert result.exit_code == 0
 
@@ -61,10 +62,11 @@ class TestCacheClearCommand:
 
         with patch("moment_to_action._cli.init_logging"):
             with patch(
-                "moment_to_action._cli.commands.cmd_cache.cmd_clear.PathManager",
+                "moment_to_action._cli.PathManager",
                 return_value=_patched_path_manager(_make_cache_info(0)),
             ):
-                result = CliRunner().invoke(cli, ["cache", "clear", "--force"])
+                with patch("moment_to_action._cli.load_config", return_value=AppConfig()):
+                    result = CliRunner().invoke(cli, ["cache", "clear", "--force"])
 
         assert result.exit_code == 0
         assert "empty" in result.output.lower()
@@ -75,10 +77,11 @@ class TestCacheClearCommand:
 
         with patch("moment_to_action._cli.init_logging"):
             with patch(
-                "moment_to_action._cli.commands.cmd_cache.cmd_clear.PathManager",
+                "moment_to_action._cli.PathManager",
                 return_value=_patched_path_manager(_make_cache_info(100_000_000)),
             ):
-                result = CliRunner().invoke(cli, ["cache", "clear", "--force"])
+                with patch("moment_to_action._cli.load_config", return_value=AppConfig()):
+                    result = CliRunner().invoke(cli, ["cache", "clear", "--force"])
 
         assert result.exit_code == 0
         assert "cleared" in result.output.lower()
@@ -89,10 +92,11 @@ class TestCacheClearCommand:
 
         with patch("moment_to_action._cli.init_logging"):
             with patch(
-                "moment_to_action._cli.commands.cmd_cache.cmd_clear.PathManager",
+                "moment_to_action._cli.PathManager",
                 return_value=_patched_path_manager(_make_cache_info(100_000_000)),
             ):
-                result = CliRunner().invoke(cli, ["cache", "clear", "--force", "--json"])
+                with patch("moment_to_action._cli.load_config", return_value=AppConfig()):
+                    result = CliRunner().invoke(cli, ["cache", "clear", "--force", "--json"])
 
         assert result.exit_code == 0
         output_json = json.loads(result.output)
@@ -105,10 +109,11 @@ class TestCacheClearCommand:
         freed = 100_000_000
         with patch("moment_to_action._cli.init_logging"):
             with patch(
-                "moment_to_action._cli.commands.cmd_cache.cmd_clear.PathManager",
+                "moment_to_action._cli.PathManager",
                 return_value=_patched_path_manager(_make_cache_info(freed)),
             ):
-                result = CliRunner().invoke(cli, ["cache", "clear", "--force", "--json"])
+                with patch("moment_to_action._cli.load_config", return_value=AppConfig()):
+                    result = CliRunner().invoke(cli, ["cache", "clear", "--force", "--json"])
 
         assert result.exit_code == 0
         output_json = json.loads(result.output)
@@ -122,11 +127,9 @@ class TestCacheClearCommand:
 
         mock_path_man = _patched_path_manager(_make_cache_info(0))
         with patch("moment_to_action._cli.init_logging"):
-            with patch(
-                "moment_to_action._cli.commands.cmd_cache.cmd_clear.PathManager",
-                return_value=mock_path_man,
-            ):
-                result = CliRunner().invoke(cli, ["cache", "clear"], input="n\n")
+            with patch("moment_to_action._cli.PathManager", return_value=mock_path_man):
+                with patch("moment_to_action._cli.load_config", return_value=AppConfig()):
+                    result = CliRunner().invoke(cli, ["cache", "clear"], input="n\n")
 
         assert result.exit_code == 0
         assert "cancelled" in result.output.lower()
@@ -138,11 +141,9 @@ class TestCacheClearCommand:
 
         mock_path_man = _patched_path_manager(_make_cache_info(100_000_000))
         with patch("moment_to_action._cli.init_logging"):
-            with patch(
-                "moment_to_action._cli.commands.cmd_cache.cmd_clear.PathManager",
-                return_value=mock_path_man,
-            ):
-                result = CliRunner().invoke(cli, ["cache", "clear"], input="y\n")
+            with patch("moment_to_action._cli.PathManager", return_value=mock_path_man):
+                with patch("moment_to_action._cli.load_config", return_value=AppConfig()):
+                    result = CliRunner().invoke(cli, ["cache", "clear"], input="y\n")
 
         assert result.exit_code == 0
         mock_path_man.cache.clear_cache.assert_called_once()
@@ -153,11 +154,9 @@ class TestCacheClearCommand:
 
         mock_path_man = _patched_path_manager(_make_cache_info(0))
         with patch("moment_to_action._cli.init_logging"):
-            with patch(
-                "moment_to_action._cli.commands.cmd_cache.cmd_clear.PathManager",
-                return_value=mock_path_man,
-            ):
-                result = CliRunner().invoke(cli, ["cache", "clear", "--json"])
+            with patch("moment_to_action._cli.PathManager", return_value=mock_path_man):
+                with patch("moment_to_action._cli.load_config", return_value=AppConfig()):
+                    result = CliRunner().invoke(cli, ["cache", "clear", "--json"])
 
         assert result.exit_code == 0
         output_json = json.loads(result.output)
@@ -166,13 +165,13 @@ class TestCacheClearCommand:
 
     def test_eoferror_in_non_interactive_proceeds_without_confirmation(self) -> None:
         """Clear handles EOFError in non-interactive mode by proceeding."""
+        from moment_to_action._cli import cli
+
         mock_path_man = _patched_path_manager(_make_cache_info(0))
-        with patch(
-            "moment_to_action._cli.commands.cmd_cache.cmd_clear.PathManager",
-            return_value=mock_path_man,
-        ):
-            with patch("moment_to_action._cli.init_logging"):
-                result = CliRunner().invoke(clear, [], input="")
+        with patch("moment_to_action._cli.init_logging"):
+            with patch("moment_to_action._cli.PathManager", return_value=mock_path_man):
+                with patch("moment_to_action._cli.load_config", return_value=AppConfig()):
+                    result = CliRunner().invoke(cli, ["cache", "clear"], input="")
 
         assert result.exit_code == 0
         mock_path_man.cache.clear_cache.assert_called_once()

--- a/tests/unit/cli/commands/cache/test_cmd_cache_inspect.py
+++ b/tests/unit/cli/commands/cache/test_cmd_cache_inspect.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from click.testing import CliRunner
 
+from moment_to_action.config import AppConfig
 from moment_to_action.paths._cache._manager import CacheInfo
 from moment_to_action.paths._cache._models import CachedModelInfo, ModelCacheContents
 
@@ -61,12 +62,11 @@ class TestCacheInspectCommand:
                 ),
             },
         )
+        mock_pm = _patched_path_manager(info)
         with patch("moment_to_action._cli.init_logging"):
-            with patch(
-                "moment_to_action._cli.commands.cmd_cache.cmd_inspect.PathManager",
-                return_value=_patched_path_manager(info),
-            ):
-                result = CliRunner().invoke(cli, ["cache", "inspect"])
+            with patch("moment_to_action._cli.PathManager", return_value=mock_pm):
+                with patch("moment_to_action._cli.load_config", return_value=AppConfig()):
+                    result = CliRunner().invoke(cli, ["cache", "inspect"])
 
         assert result.exit_code == 0
         assert "Cache" in result.output
@@ -78,12 +78,11 @@ class TestCacheInspectCommand:
         from moment_to_action._cli import cli
 
         info = _make_cache_info(0)
+        mock_pm = _patched_path_manager(info)
         with patch("moment_to_action._cli.init_logging"):
-            with patch(
-                "moment_to_action._cli.commands.cmd_cache.cmd_inspect.PathManager",
-                return_value=_patched_path_manager(info),
-            ):
-                result = CliRunner().invoke(cli, ["cache", "inspect", "--json"])
+            with patch("moment_to_action._cli.PathManager", return_value=mock_pm):
+                with patch("moment_to_action._cli.load_config", return_value=AppConfig()):
+                    result = CliRunner().invoke(cli, ["cache", "inspect", "--json"])
 
         assert result.exit_code == 0
         output_json = json.loads(result.output)
@@ -104,12 +103,11 @@ class TestCacheInspectCommand:
                 ),
             },
         )
+        mock_pm = _patched_path_manager(info)
         with patch("moment_to_action._cli.init_logging"):
-            with patch(
-                "moment_to_action._cli.commands.cmd_cache.cmd_inspect.PathManager",
-                return_value=_patched_path_manager(info),
-            ):
-                result = CliRunner().invoke(cli, ["cache", "inspect", "--json"])
+            with patch("moment_to_action._cli.PathManager", return_value=mock_pm):
+                with patch("moment_to_action._cli.load_config", return_value=AppConfig()):
+                    result = CliRunner().invoke(cli, ["cache", "inspect", "--json"])
 
         assert result.exit_code == 0
         output_json = json.loads(result.output)
@@ -123,12 +121,13 @@ class TestCacheInspectCommand:
 
         with patch("moment_to_action._cli.init_logging"):
             with patch(
-                "moment_to_action._cli.commands.cmd_cache.cmd_inspect.PathManager",
+                "moment_to_action._cli.PathManager",
                 return_value=_patched_path_manager(_make_cache_info(0)),
             ):
-                runner = CliRunner()
-                result_default = runner.invoke(cli, ["cache", "inspect"])
-                result_json = runner.invoke(cli, ["cache", "inspect", "--json"])
+                with patch("moment_to_action._cli.load_config", return_value=AppConfig()):
+                    runner = CliRunner()
+                    result_default = runner.invoke(cli, ["cache", "inspect"])
+                    result_json = runner.invoke(cli, ["cache", "inspect", "--json"])
 
         assert result_default.exit_code == 0
         assert result_json.exit_code == 0

--- a/tests/unit/cli/test_init.py
+++ b/tests/unit/cli/test_init.py
@@ -24,6 +24,10 @@ class TestMainModule:
 class TestCliCommand:
     """Tests for the top-level cli Click group."""
 
+    @pytest.fixture(autouse=True)
+    def _patch_platform_dirs(self, path_manager: object) -> None:
+        """Activate path_manager fixture so PathManager() uses tmp_path."""
+
     def _mock_backend(self) -> MagicMock:
         sample = MagicMock()
         sample.power_mw = 100
@@ -42,8 +46,8 @@ class TestCliCommand:
         assert result.exit_code == 0
         assert "read-power" in result.output or "rdpwr" in result.output
 
-    def test_cli_verbose_flag_calls_init_logging_with_true(self) -> None:
-        """--verbose causes init_logging(verbose=True)."""
+    def test_cli_verbose_flag_calls_init_logging_with_debug(self) -> None:
+        """--verbose overrides config and calls init_logging with log_level='DEBUG'."""
         from moment_to_action._cli import cli
 
         with patch("moment_to_action._cli.init_logging") as mock_init:
@@ -53,10 +57,10 @@ class TestCliCommand:
             ):
                 result = CliRunner().invoke(cli, ["--verbose", "read-power", "CPU"])
         assert result.exit_code == 0
-        mock_init.assert_called_once_with(verbose=True)
+        mock_init.assert_called_once_with(log_level="DEBUG")
 
-    def test_cli_default_verbose_false(self) -> None:
-        """Without --verbose, init_logging is called with verbose=False."""
+    def test_cli_default_uses_config_log_level(self) -> None:
+        """Without --verbose, init_logging is called with config log_level."""
         from moment_to_action._cli import cli
 
         with patch("moment_to_action._cli.init_logging") as mock_init:
@@ -66,7 +70,7 @@ class TestCliCommand:
             ):
                 result = CliRunner().invoke(cli, ["read-power", "CPU"])
         assert result.exit_code == 0
-        mock_init.assert_called_once_with(verbose=False)
+        mock_init.assert_called_once_with(log_level="INFO")
 
     def test_cli_seed_option_accepted(self) -> None:
         """--seed with a hex value is accepted without error."""

--- a/tests/unit/test_cli_config.py
+++ b/tests/unit/test_cli_config.py
@@ -1,0 +1,88 @@
+"""Unit tests for m2a config CLI command."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner, Result
+
+if TYPE_CHECKING:
+    from moment_to_action.paths import PathManager
+
+
+@pytest.mark.unit
+class TestConfigCommand:
+    """Tests for the `m2a config` command."""
+
+    @pytest.fixture
+    def runner(self) -> CliRunner:
+        """Return a Click test runner."""
+        return CliRunner()
+
+    @pytest.fixture(autouse=True)
+    def _patch_path_manager(
+        self, path_manager: PathManager, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Patch PathManager in CLI init to use tmp_path-rooted paths."""
+        monkeypatch.setattr(
+            "moment_to_action._cli.PathManager",
+            lambda: path_manager,
+        )
+
+    def _invoke(self, runner: CliRunner, args: list[str]) -> Result:
+        from moment_to_action._cli import cli
+
+        with patch("moment_to_action._cli.init_logging"):
+            return runner.invoke(cli, ["config", *args])
+
+    def test_no_args_prints_rich_table(self, runner: CliRunner) -> None:
+        """No arguments prints full config as a rich table."""
+        result = self._invoke(runner, [])
+        assert result.exit_code == 0
+        assert "max_workers" in result.output
+        assert "log_level" in result.output
+
+    def test_no_args_json_flag(self, runner: CliRunner) -> None:
+        """No arguments with --json prints full config as JSON."""
+        result = self._invoke(runner, ["--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "max_workers" in data
+        assert "log_level" in data
+
+    def test_get_key(self, runner: CliRunner) -> None:
+        """KEY only prints the current value."""
+        result = self._invoke(runner, ["log_level"])
+        assert result.exit_code == 0
+        assert "INFO" in result.output
+
+    def test_set_key(self, runner: CliRunner) -> None:
+        """KEY VALUE sets the value and prints confirmation."""
+        result = self._invoke(runner, ["max_workers", "4"])
+        assert result.exit_code == 0
+        assert "max_workers = 4" in result.output
+
+    def test_set_persists_value(self, runner: CliRunner) -> None:
+        """Setting a value persists so a subsequent get returns the new value."""
+        self._invoke(runner, ["max_workers", "6"])
+        result = self._invoke(runner, ["max_workers"])
+        assert result.exit_code == 0
+        assert "6" in result.output
+
+    def test_unknown_key_errors(self, runner: CliRunner) -> None:
+        """Unknown key returns a non-zero exit code."""
+        result = self._invoke(runner, ["nonexistent_key"])
+        assert result.exit_code != 0
+
+    def test_invalid_value_errors(self, runner: CliRunner) -> None:
+        """Passing a value that fails pydantic validation returns a non-zero exit code."""
+        result = self._invoke(runner, ["max_workers", "not_a_number"])
+        assert result.exit_code != 0
+
+    def test_invalid_log_level_errors(self, runner: CliRunner) -> None:
+        """Passing an invalid log level returns a non-zero exit code."""
+        result = self._invoke(runner, ["log_level", "TRACE"])
+        assert result.exit_code != 0

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,129 @@
+"""Unit tests for config module."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from pydantic import ValidationError
+
+from moment_to_action.config import AppConfig, load_config, save_config
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from moment_to_action.paths import PathManager
+
+
+@pytest.mark.unit
+class TestAppConfig:
+    """Tests for AppConfig model."""
+
+    def test_default_max_workers(self) -> None:
+        """max_workers defaults to cpu_count (at least 1)."""
+        config = AppConfig()
+        assert config.max_workers >= 1
+
+    def test_default_log_level(self) -> None:
+        """log_level defaults to INFO."""
+        config = AppConfig()
+        assert config.log_level == "INFO"
+
+    def test_max_workers_ge1_validation(self) -> None:
+        """max_workers=0 raises ValidationError."""
+        with pytest.raises(ValidationError):
+            AppConfig(max_workers=0)
+
+    def test_log_level_invalid_raises(self) -> None:
+        """Unknown log level raises ValidationError."""
+        with pytest.raises(ValidationError):
+            AppConfig(log_level="TRACE")  # type: ignore[arg-type]
+
+    def test_custom_values(self) -> None:
+        """Custom field values are stored correctly."""
+        config = AppConfig(max_workers=4, log_level="DEBUG")
+        assert config.max_workers == 4
+        assert config.log_level == "DEBUG"
+
+
+@pytest.mark.unit
+class TestLoadConfig:
+    """Tests for load_config."""
+
+    def test_load_creates_file_when_missing(self, path_manager: PathManager) -> None:
+        """load_config writes default file when path does not exist."""
+        path = path_manager.app_config_file
+        assert not path.exists()
+        load_config(path)
+        assert path.exists()
+
+    def test_load_returns_defaults_when_missing(self, path_manager: PathManager) -> None:
+        """load_config returns default AppConfig when file absent."""
+        config = load_config(path_manager.app_config_file)
+        assert config.max_workers >= 1
+        assert config.log_level == "INFO"
+
+    def test_load_existing_file(self, path_manager: PathManager) -> None:
+        """load_config parses an existing config file correctly."""
+        path = path_manager.app_config_file
+        save_config(AppConfig(max_workers=4, log_level="DEBUG"), path)
+
+        config = load_config(path)
+        assert config.max_workers == 4
+        assert config.log_level == "DEBUG"
+
+    def test_load_normalizes_format(self, path_manager: PathManager) -> None:
+        """load_config re-saves the file to normalize its format."""
+        path = path_manager.app_config_file
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # Write non-normalized JSON (compact, no indent)
+        path.write_text('{"max_workers":2,"log_level":"WARNING"}')
+
+        load_config(path)
+
+        # File should now have indented format
+        content = path.read_text()
+        assert "\n" in content  # indented output contains newlines
+
+    def test_load_partial_json_fills_defaults(self, path_manager: PathManager) -> None:
+        """load_config fills missing fields with defaults when file has partial data."""
+        path = path_manager.app_config_file
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text('{"max_workers": 3}')
+
+        config = load_config(path)
+        assert config.max_workers == 3
+        assert config.log_level == "INFO"
+
+
+@pytest.mark.unit
+class TestSaveConfig:
+    """Tests for save_config."""
+
+    def test_save_writes_json(self, tmp_path: Path) -> None:
+        """save_config writes valid JSON to the given path."""
+        import json
+
+        path = tmp_path / "config.json"
+        config = AppConfig(max_workers=2, log_level="WARNING")
+        save_config(config, path)
+
+        data = json.loads(path.read_text())
+        assert data["max_workers"] == 2
+        assert data["log_level"] == "WARNING"
+
+    def test_save_creates_parent_dirs(self, tmp_path: Path) -> None:
+        """save_config creates parent directories if they do not exist."""
+        path = tmp_path / "deep" / "nested" / "config.json"
+        save_config(AppConfig(), path)
+        assert path.exists()
+
+    def test_roundtrip(self, tmp_path: Path) -> None:
+        """Save then load returns the same config values."""
+        path = tmp_path / "config.json"
+        original = AppConfig(max_workers=8, log_level="ERROR")
+        save_config(original, path)
+
+        loaded = load_config(path)
+        assert loaded.max_workers == original.max_workers
+        assert loaded.log_level == original.log_level

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -14,24 +14,30 @@ from moment_to_action._logging import init_logging
 class TestInitLogging:
     """Tests for init_logging."""
 
-    def test_verbose_sets_debug_level(self) -> None:
-        """verbose=True configures the root logger at DEBUG."""
+    def test_debug_level(self) -> None:
+        """log_level='DEBUG' configures the root logger at DEBUG."""
         with patch("logging.basicConfig") as mock_cfg:
-            init_logging(verbose=True)
+            init_logging(log_level="DEBUG")
             assert mock_cfg.call_args.kwargs["level"] == logging.DEBUG
 
-    def test_non_verbose_sets_info_level(self) -> None:
-        """verbose=False configures the root logger at INFO."""
+    def test_info_level(self) -> None:
+        """log_level='INFO' configures the root logger at INFO."""
         with patch("logging.basicConfig") as mock_cfg:
-            init_logging(verbose=False)
+            init_logging(log_level="INFO")
             assert mock_cfg.call_args.kwargs["level"] == logging.INFO
+
+    def test_warning_level(self) -> None:
+        """log_level='WARNING' configures the root logger at WARNING."""
+        with patch("logging.basicConfig") as mock_cfg:
+            init_logging(log_level="WARNING")
+            assert mock_cfg.call_args.kwargs["level"] == logging.WARNING
 
     def test_installs_rich_handler(self) -> None:
         """init_logging installs exactly one RichHandler."""
         from rich.logging import RichHandler
 
         with patch("logging.basicConfig") as mock_cfg:
-            init_logging(verbose=False)
+            init_logging(log_level="INFO")
             handlers = mock_cfg.call_args.kwargs["handlers"]
             assert len(handlers) == 1
             assert isinstance(handlers[0], RichHandler)

--- a/tests/unit/utils/test_cli.py
+++ b/tests/unit/utils/test_cli.py
@@ -26,8 +26,12 @@ class TestCliUtils:
 
     def test_get_global_data_found(self) -> None:
         """Returns GlobalData when ctx.obj is a GlobalData instance."""
+        from unittest.mock import MagicMock
+
+        from moment_to_action.config import AppConfig
+
         ctx = _make_ctx()
-        gd = GlobalData(log=logging.getLogger("test"))
+        gd = GlobalData(log=logging.getLogger("test"), path_manager=MagicMock(), config=AppConfig())
         ctx.obj = gd
         assert get_global_data(ctx) is gd
 


### PR DESCRIPTION
## Summary
- New AppConfig module with JSON persistence via PathManager
- CLI config subcommand for inspecting and managing application configuration
- CLAUDE.md with development tooling, architecture, conventions, and contributing flow
- Comprehensive tests for config module and CLI integration
- Updated CLI patterns to use GlobalData decorator for consistent context passing

## Technical Details
- AppConfig is a Pydantic model persisted at path_mgr.app_config_file
- Config subcommand mirrors cache command structure using AutoRichGroup
- PathManager integration ensures consistent path handling across modules
- All tests maintain 100% coverage requirement

## Verification
- [x] Unit tests
- [x] Integration tests
- [x] Manual testing: config subcommand lists and inspects configuration
- [x] Lint and type checks pass; coverage at 100%

Closes #95