### PR TITLE
Add QAIRT SDK commands and dependency manager

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,7 @@ Entry point `m2a` (`pyproject.toml` `[project.scripts]`) → `moment_to_action._
 ### Style
 - `from __future__ import annotations` at the top of every file.
 - Line length 100. Google-style docstrings (`[tool.ruff.lint.pydocstyle].convention = "google"`).
+- **Every function and method must have a docstring** describing its purpose, arguments, return value, and exceptions. Include `__init__` docstrings with all parameters. Use Google style: `Args:`, `Returns:`, `Raises:` sections.
 - Use `object` instead of `Any` except where a runtime handle is genuinely opaque (`_ModelHandle.raw` is the one sanctioned `Any`).
 - Type-checker-only imports go under `if TYPE_CHECKING:`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,5 +110,5 @@ In-repo design docs live in `docs/`. Consult before touching the relevant subsys
 1. Branch off `main` as `<your_name>/<feature>` (e.g. `nikola/add-logging`).
 2. Write code **and tests**; keep coverage at 100%.
 3. `just lint && just test` clean locally.
-4. Open PR to `main` using `.github/pull_request_template.md`; GitHub Actions runs lint + tests.
+4. Open PR to `main` using `.github/pull_request_template.md` **EXACTLY**; GitHub Actions runs lint + tests.
 5. Merge as a **squash commit**.

--- a/src/moment_to_action/_cli/__init__.py
+++ b/src/moment_to_action/_cli/__init__.py
@@ -1,3 +1,4 @@
+import contextlib
 import logging
 from pathlib import Path
 
@@ -6,6 +7,7 @@ import rich_click as click
 from moment_to_action._logging import init_logging
 from moment_to_action.config import load_config
 from moment_to_action.paths import PathManager
+from moment_to_action.qairt import QairtSDKManager
 from moment_to_action.utils.cli import GlobalData, ctx_get_seed, ctx_set_seed
 
 from ._auto_group import auto_group
@@ -41,6 +43,11 @@ def cli(ctx: click.Context, *, verbose: bool, seed: int | None) -> None:
 
     # Build global data object
     ctx.obj = GlobalData(log=log, path_manager=path_manager, config=config)
+
+    # Set QAIRT_SDK_ROOT in this process if SDK is configured
+    if config.qairt_sdk_path is not None:
+        with contextlib.suppress(RuntimeError):
+            QairtSDKManager.from_app_config(config, path_manager).configure_env()
 
     # Set seed
     ctx_set_seed(ctx, seed)

--- a/src/moment_to_action/_cli/commands/cmd_config.py
+++ b/src/moment_to_action/_cli/commands/cmd_config.py
@@ -9,6 +9,7 @@ from rich.table import Table
 
 from moment_to_action.config import AppConfig, save_config
 from moment_to_action.utils.cli import GlobalData, pass_global_data
+from moment_to_action.utils.schemas import update_frozen
 
 
 @click.command()
@@ -51,7 +52,7 @@ def config(data: GlobalData, key: str | None, value: str | None, *, json_output:
         return
 
     try:
-        updated = AppConfig.model_validate({**cfg.model_dump(), key: value})
+        updated = update_frozen(cfg, **{key: value})
     except ValidationError as e:
         raise click.BadParameter(str(e)) from e
 

--- a/src/moment_to_action/_cli/commands/cmd_qairt/__init__.py
+++ b/src/moment_to_action/_cli/commands/cmd_qairt/__init__.py
@@ -1,0 +1,12 @@
+"""QAIRT SDK management subcommand group."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from moment_to_action._cli._auto_group import auto_group
+
+
+@auto_group(cmd_path=Path(__file__).parent)
+def qairt() -> None:
+    """Manage the QAIRT SDK (install, verify, info, clean)."""

--- a/src/moment_to_action/_cli/commands/cmd_qairt/cmd_clean.py
+++ b/src/moment_to_action/_cli/commands/cmd_qairt/cmd_clean.py
@@ -1,0 +1,52 @@
+"""Remove QAIRT SDK command."""
+
+from __future__ import annotations
+
+import json
+
+import rich_click as click
+from rich.console import Console
+
+from moment_to_action.config import save_config
+from moment_to_action.qairt import QairtSDKManager
+from moment_to_action.utils.cli import GlobalData, pass_global_data
+from moment_to_action.utils.schemas import update_frozen
+
+
+@click.command()
+@click.option("--force", is_flag=True, help="Skip confirmation prompt.")
+@click.option("--json", "json_output", is_flag=True, help="Output result as JSON.")
+@pass_global_data
+def clean(data: GlobalData, *, force: bool, json_output: bool) -> None:
+    """Remove the installed QAIRT SDK.
+
+    Deletes the SDK directory and clears the configured path from the
+    application config. Use --force to skip the confirmation prompt.
+    """
+    mgr = QairtSDKManager.from_app_config(data.config, data.path_manager)
+
+    if not force and not json_output:
+        console = Console()
+        try:
+            confirmed = console.input(
+                "[yellow]This will remove the QAIRT SDK directory. Continue? \\[y/N][/yellow] "
+            )
+            if confirmed.lower() not in ("y", "yes"):
+                console.print("[cyan]Cancelled.[/cyan]")
+                return
+        except EOFError:
+            pass
+
+    try:
+        removed = mgr.clean()
+    except RuntimeError as e:
+        raise click.ClickException(str(e)) from e
+
+    updated = update_frozen(data.config, qairt_sdk_path=None)
+    save_config(updated, data.path_manager.app_config_file)
+    data.config = updated
+
+    if json_output:
+        click.echo(json.dumps({"removed": str(removed)}))
+    else:
+        Console().print(f"[green]✓ Removed QAIRT SDK[/green] {removed}")

--- a/src/moment_to_action/_cli/commands/cmd_qairt/cmd_info.py
+++ b/src/moment_to_action/_cli/commands/cmd_qairt/cmd_info.py
@@ -1,0 +1,47 @@
+"""QAIRT SDK info command."""
+
+from __future__ import annotations
+
+import json
+
+import rich_click as click
+from rich.console import Console
+from rich.table import Table
+
+from moment_to_action.qairt import QairtSDKManager
+from moment_to_action.utils.cli import GlobalData, pass_global_data
+
+
+@click.command()
+@click.option("--json", "json_output", is_flag=True, help="Output as JSON.")
+@pass_global_data
+def info(data: GlobalData, *, json_output: bool) -> None:
+    """Show QAIRT SDK information.
+
+    Displays the configured version, installed path, availability, and the
+    full version string (including build number) derived from the install path.
+    """
+    mgr = QairtSDKManager.from_app_config(data.config, data.path_manager)
+
+    if json_output:
+        click.echo(
+            json.dumps(
+                {
+                    "configured_version": mgr.configured_version,
+                    "installed_version": mgr.installed_version,
+                    "path": str(mgr.path) if mgr.path else None,
+                    "available": mgr.is_available,
+                },
+                indent=2,
+            )
+        )
+        return
+
+    table = Table(title="QAIRT SDK")
+    table.add_column("Field")
+    table.add_column("Value")
+    table.add_row("Configured version", mgr.configured_version)
+    table.add_row("Installed version", mgr.installed_version or "[dim]not installed[/dim]")
+    table.add_row("Path", str(mgr.path) if mgr.path else "[dim]not installed[/dim]")
+    table.add_row("Available", "[green]yes[/green]" if mgr.is_available else "[red]no[/red]")
+    Console().print(table)

--- a/src/moment_to_action/_cli/commands/cmd_qairt/cmd_install.py
+++ b/src/moment_to_action/_cli/commands/cmd_qairt/cmd_install.py
@@ -39,7 +39,14 @@ def install(data: GlobalData, *, json_output: bool) -> None:
     try:
         sdk_path = mgr.install(stream=not json_output)
     except RuntimeError as e:
-        raise click.ClickException(str(e)) from e
+        error_msg = str(e)
+        if "already installed" in error_msg:
+            if not click.confirm(f"{error_msg}\n\nReinstall?"):
+                raise click.Abort from e
+            mgr.clean()
+            sdk_path = mgr.install(stream=not json_output)
+        else:
+            raise click.ClickException(error_msg) from e
 
     updated = update_frozen(data.config, qairt_sdk_path=sdk_path)
     save_config(updated, data.path_manager.app_config_file)

--- a/src/moment_to_action/_cli/commands/cmd_qairt/cmd_install.py
+++ b/src/moment_to_action/_cli/commands/cmd_qairt/cmd_install.py
@@ -1,0 +1,56 @@
+"""Install QAIRT SDK command."""
+
+from __future__ import annotations
+
+import json
+
+import rich_click as click
+from rich.console import Console
+
+from moment_to_action.config import save_config
+from moment_to_action.qairt import QairtSDKManager
+from moment_to_action.utils.cli import GlobalData, pass_global_data
+from moment_to_action.utils.schemas import update_frozen
+
+
+@click.command()
+@click.option("--json", "json_output", is_flag=True, help="Output result as JSON.")
+@pass_global_data
+def install(data: GlobalData, *, json_output: bool) -> None:
+    """Install the QAIRT SDK.
+
+    Downloads and extracts the configured SDK version into the application data
+    directory. The installed path is saved to config so other commands can find it.
+
+    Checks required system packages before downloading and runs a post-install
+    verification check after a successful install.
+    """
+    console = Console(stderr=True)
+    mgr = QairtSDKManager.from_app_config(data.config, data.path_manager)
+
+    missing = mgr.check_system_deps()
+    if missing:
+        console.print(
+            f"[red]Missing system packages:[/red] {', '.join(missing)}\n"
+            "Install them before running 'm2a qairt install'."
+        )
+        raise click.Abort
+
+    try:
+        sdk_path = mgr.install(stream=not json_output)
+    except RuntimeError as e:
+        raise click.ClickException(str(e)) from e
+
+    updated = update_frozen(data.config, qairt_sdk_path=sdk_path)
+    save_config(updated, data.path_manager.app_config_file)
+    data.config = updated
+
+    for issue in mgr.verify(stream=not json_output):
+        data.log.warning(issue)
+
+    if json_output:
+        click.echo(json.dumps({"path": str(sdk_path), "version": mgr.installed_version}))
+    else:
+        Console().print(
+            f"[green]✓ Installed QAIRT SDK {mgr.installed_version}[/green] → {sdk_path}"
+        )

--- a/src/moment_to_action/_cli/commands/cmd_qairt/cmd_verify.py
+++ b/src/moment_to_action/_cli/commands/cmd_qairt/cmd_verify.py
@@ -1,0 +1,27 @@
+"""Verify QAIRT SDK installation command."""
+
+from __future__ import annotations
+
+import rich_click as click
+
+from moment_to_action.qairt import QairtSDKManager
+from moment_to_action.utils.cli import GlobalData, pass_global_data
+
+
+@click.command()
+@pass_global_data
+def verify(data: GlobalData) -> None:
+    """Verify the QAIRT SDK installation.
+
+    Checks that the configured SDK path exists and all required system
+    packages are installed. Exits 1 if any issues are found.
+    """
+    mgr = QairtSDKManager.from_app_config(data.config, data.path_manager)
+    try:
+        issues = mgr.verify(stream=True)
+    except RuntimeError as e:
+        raise click.ClickException(str(e)) from e
+    for issue in issues:
+        data.log.warning(issue)
+    if issues:
+        raise SystemExit(1)

--- a/src/moment_to_action/config.py
+++ b/src/moment_to_action/config.py
@@ -3,19 +3,19 @@
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING, Literal
+from pathlib import Path  # noqa: TC003
+from typing import Literal
 
 from pydantic import BaseModel, Field
 
-if TYPE_CHECKING:
-    from pathlib import Path
 
-
-class AppConfig(BaseModel):
+class AppConfig(BaseModel, frozen=True):
     """Application configuration."""
 
     max_workers: int = Field(default_factory=lambda: os.cpu_count() or 1, ge=1)
     log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = "INFO"
+    qairt_sdk_version: str = "2.45.0"
+    qairt_sdk_path: Path | None = None
 
 
 def load_config(path: Path) -> AppConfig:

--- a/src/moment_to_action/qairt/__init__.py
+++ b/src/moment_to_action/qairt/__init__.py
@@ -1,0 +1,7 @@
+"""QAIRT SDK management."""
+
+from __future__ import annotations
+
+from moment_to_action.qairt._manager import QairtSDKManager
+
+__all__ = ["QairtSDKManager"]

--- a/src/moment_to_action/qairt/_deps.py
+++ b/src/moment_to_action/qairt/_deps.py
@@ -1,0 +1,88 @@
+"""System dependency checking for QAIRT SDK installation."""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+
+_LOG = logging.getLogger(__name__)
+
+_APT_DEPS: list[str] = [
+    "libncurses5",
+    "libgl1",
+    "clang",
+    "libc++-dev",
+    "libc++abi-dev",
+    "flatbuffers-compiler",
+    "libflatbuffers-dev",
+    "rename",
+    "unzip",
+    "zip",
+    "ca-certificates",
+    "curl",
+    "locales",
+    "lsb-release",
+    "wget",
+]
+
+# Fedora/RHEL equivalents.
+# Notes:
+# - `rename` (Perl rename) → `prename` on Fedora 35+.
+# - `lsb-release` → `redhat-lsb` on Fedora 35+ (`redhat-lsb-core` removed in Fedora 34).
+_DNF_DEPS: list[str] = [
+    "ncurses-compat-libs",
+    "mesa-libGL",
+    "clang",
+    "libcxx-devel",
+    "libcxxabi-devel",
+    "flatbuffers",
+    "flatbuffers-devel",
+    "prename",
+    "unzip",
+    "zip",
+    "ca-certificates",
+    "curl",
+    "glibc-langpack-en",
+    "redhat-lsb",
+    "wget2",
+]
+
+
+def _missing_apt(deps: list[str]) -> list[str]:
+    missing: list[str] = []
+    for p in deps:
+        cmd = ["dpkg", "-s", p]
+        if subprocess.run(cmd, capture_output=True, check=False).returncode != 0:  # noqa: S603
+            missing.append(p)
+    return missing
+
+
+def _missing_dnf(deps: list[str]) -> list[str]:
+    missing: list[str] = []
+    for p in deps:
+        cmd = ["rpm", "-q", p]
+        if subprocess.run(cmd, capture_output=True, check=False).returncode != 0:  # noqa: S603
+            missing.append(p)
+    return missing
+
+
+def check_system_deps() -> list[str]:
+    """Return list of missing system package names for the current distro.
+
+    On non-Ubuntu systems a warning is logged; package checks still run where
+    possible but results may differ from the officially supported platform.
+    """
+    if shutil.which("dpkg"):
+        return _missing_apt(_APT_DEPS)
+    if shutil.which("rpm"):
+        _LOG.warning(
+            "QAIRT SDK is officially supported on Ubuntu only; "
+            "package check results may differ on this system."
+        )
+        return _missing_dnf(_DNF_DEPS)
+    _LOG.warning(
+        "Cannot check system dependencies: no dpkg or rpm found. "
+        "QAIRT SDK is officially supported on Ubuntu only."
+    )
+    return []

--- a/src/moment_to_action/qairt/_manager.py
+++ b/src/moment_to_action/qairt/_manager.py
@@ -1,0 +1,176 @@
+"""QAIRT SDK manager."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from moment_to_action.config import AppConfig
+    from moment_to_action.paths import PathManager
+
+_QAIRT_VM = Path(sys.executable).parent / "qairt-vm"
+
+_ERR_NOT_INSTALLED = "SDK not installed; run 'm2a qairt install' first"
+_ERR_NOT_INSTALLED_M2A = "SDK not installed via m2a"
+_ERR_FETCH_PATH = "fetch succeeded but SDK path not found under install dir"
+
+
+class QairtSDKManager:
+    """Manages the QAIRT SDK installation for this application."""
+
+    def __init__(self, sdk_path: Path | None, sdk_version: str, install_dir: Path) -> None:
+        self._sdk_path = sdk_path
+        self._sdk_version = sdk_version
+        self._install_dir = install_dir
+
+    @classmethod
+    def from_app_config(cls, config: AppConfig, path_manager: PathManager) -> QairtSDKManager:
+        """Construct from application config and path manager."""
+        return cls(
+            sdk_path=config.qairt_sdk_path,
+            sdk_version=config.qairt_sdk_version,
+            install_dir=path_manager.data.data_dir,
+        )
+
+    # --- Properties (pure state, no subprocess) ---
+
+    @property
+    def is_available(self) -> bool:
+        """True if SDK path is configured and the directory exists on disk."""
+        return self._sdk_path is not None and self._sdk_path.exists()
+
+    @property
+    def path(self) -> Path | None:
+        """Configured SDK path, or None if not installed."""
+        return self._sdk_path
+
+    @property
+    def configured_version(self) -> str:
+        """Version string that will be fetched on install."""
+        return self._sdk_version
+
+    @property
+    def installed_version(self) -> str | None:
+        """Full version string (e.g. '2.45.0.24') from the installed directory name.
+
+        Returns None if SDK is not available.
+        """
+        if not self.is_available:
+            return None
+        assert self._sdk_path is not None  # noqa: S101
+        return self._sdk_path.name
+
+    # --- Environment ---
+
+    def configure_env(self) -> None:
+        """Set QAIRT_SDK_ROOT in os.environ so ``import qairt`` resolves correctly.
+
+        Raises:
+            RuntimeError: If SDK path is not configured.
+        """
+        if self._sdk_path is None:
+            raise RuntimeError(_ERR_NOT_INSTALLED)
+        os.environ["QAIRT_SDK_ROOT"] = str(self._sdk_path)
+
+    # --- Operations ---
+
+    def check_system_deps(self) -> list[str]:
+        """Return list of missing system package names for the current distro."""
+        from moment_to_action.qairt._deps import check_system_deps
+
+        return check_system_deps()
+
+    def install(self, *, stream: bool = True) -> Path:
+        """Fetch the SDK and return the extracted path.
+
+        Args:
+            stream: If True, let qairt-vm output flow to the terminal. If False,
+                capture output (useful for --json mode).
+
+        Raises:
+            RuntimeError: If the fetch fails or the extracted path cannot be found.
+        """
+        result = subprocess.run(  # noqa: S603
+            [_QAIRT_VM, "fetch", "--version", self._sdk_version, "--dir", str(self._install_dir)],
+            capture_output=not stream,
+            check=False,
+        )
+        if result.returncode != 0:
+            msg = f"qairt-vm fetch failed (exit {result.returncode})"
+            raise RuntimeError(msg)
+        path = self._find_sdk_path()
+        if path is None:
+            raise RuntimeError(_ERR_FETCH_PATH)
+        self._sdk_path = path
+        return path
+
+    def verify(self, *, stream: bool = True) -> list[str]:
+        """Check SDK installation and return any warnings.
+
+        On Ubuntu (dpkg available) runs ``qairt-vm --inspect`` for full
+        verification. On other systems logs a support warning and checks path
+        and system deps only.
+
+        Args:
+            stream: If True, let qairt-vm output flow to the terminal (Ubuntu only).
+
+        Returns:
+            List of warning strings for any issues found. Empty means all good.
+
+        Raises:
+            RuntimeError: If SDK path is not configured.
+        """
+        if self._sdk_path is None:
+            raise RuntimeError(_ERR_NOT_INSTALLED)
+        issues: list[str] = []
+        if not self._sdk_path.exists():
+            issues.append(f"SDK path does not exist: {self._sdk_path}")
+        issues.extend(f"Missing system package: {pkg}" for pkg in self.check_system_deps())
+        if shutil.which("dpkg"):
+            env = {**os.environ, "QAIRT_SDK_ROOT": str(self._sdk_path)}
+            result = subprocess.run(  # noqa: S603
+                [_QAIRT_VM, "--inspect"],
+                capture_output=not stream,
+                text=True,
+                env=env,
+                check=False,
+            )
+            if result.returncode != 0:
+                issues.append(f"qairt-vm --inspect failed (exit {result.returncode})")
+        else:
+            issues.append(
+                "QAIRT SDK is officially supported on Ubuntu only; "
+                "--inspect skipped on this system."
+            )
+        return issues
+
+    def clean(self) -> Path:
+        """Remove the SDK directory.
+
+        Returns:
+            The path that was removed.
+
+        Raises:
+            RuntimeError: If SDK path is not configured.
+        """
+        if self._sdk_path is None:
+            raise RuntimeError(_ERR_NOT_INSTALLED_M2A)
+        path = self._sdk_path
+        shutil.rmtree(path, ignore_errors=True)
+        self._sdk_path = None
+        return path
+
+    # --- Internal ---
+
+    def _find_sdk_path(self) -> Path | None:
+        """Glob install_dir/qairt/<version>.* and return the first match."""
+        base = self._install_dir / "qairt"
+        if not base.exists():
+            return None
+        matches = sorted(base.glob(f"{self._sdk_version}.*"))
+        return matches[0] if matches else None

--- a/src/moment_to_action/qairt/_manager.py
+++ b/src/moment_to_action/qairt/_manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import shutil
 import subprocess
@@ -12,6 +13,8 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from moment_to_action.config import AppConfig
     from moment_to_action.paths import PathManager
+
+_log = logging.getLogger(__name__)
 
 _QAIRT_VM = Path(sys.executable).parent / "qairt-vm"
 
@@ -28,6 +31,10 @@ class QairtSDKManager:
         self._sdk_path = sdk_path
         self._sdk_version = sdk_version
         self._install_dir = install_dir
+        _log.debug(
+            f"Initialized QairtSDKManager: version={sdk_version}, "
+            f"install_dir={install_dir}, sdk_path={sdk_path}"
+        )
 
     @classmethod
     def from_app_config(cls, config: AppConfig, path_manager: PathManager) -> QairtSDKManager:
@@ -75,7 +82,9 @@ class QairtSDKManager:
             RuntimeError: If SDK path is not configured.
         """
         if self._sdk_path is None:
+            _log.error("Cannot configure environment: SDK path not set")
             raise RuntimeError(_ERR_NOT_INSTALLED)
+        _log.info(f"Setting QAIRT_SDK_ROOT={self._sdk_path}")
         os.environ["QAIRT_SDK_ROOT"] = str(self._sdk_path)
 
     # --- Operations ---
@@ -84,7 +93,12 @@ class QairtSDKManager:
         """Return list of missing system package names for the current distro."""
         from moment_to_action.qairt._deps import check_system_deps
 
-        return check_system_deps()
+        missing = check_system_deps()
+        if missing:
+            _log.warning(f"Missing system dependencies: {', '.join(missing)}")
+        else:
+            _log.debug("All system dependencies present")
+        return missing
 
     def install(self, *, stream: bool = True) -> Path:
         """Fetch the SDK and return the extracted path.
@@ -98,7 +112,12 @@ class QairtSDKManager:
         """
         if self.is_available:
             msg = _ERR_ALREADY_INSTALLED.format(version=self.installed_version, path=self._sdk_path)
+            _log.error(msg)
             raise RuntimeError(msg)
+        _log.info(
+            f"Starting QAIRT SDK install: version={self._sdk_version}, "
+            f"install_dir={self._install_dir}"
+        )
         result = subprocess.run(  # noqa: S603
             [_QAIRT_VM, "fetch", "--version", self._sdk_version, "--dir", str(self._install_dir)],
             capture_output=not stream,
@@ -106,11 +125,15 @@ class QairtSDKManager:
         )
         if result.returncode != 0:
             msg = f"qairt-vm fetch failed (exit {result.returncode})"
+            _log.error(msg)
             raise RuntimeError(msg)
+        _log.debug("qairt-vm fetch succeeded, locating SDK path")
         path = self._find_sdk_path()
         if path is None:
+            _log.error(_ERR_FETCH_PATH)
             raise RuntimeError(_ERR_FETCH_PATH)
         self._sdk_path = path
+        _log.info(f"Successfully installed QAIRT SDK {self._sdk_version} at {path}")
         return path
 
     def verify(self, *, stream: bool = True) -> list[str]:
@@ -130,12 +153,20 @@ class QairtSDKManager:
             RuntimeError: If SDK path is not configured.
         """
         if self._sdk_path is None:
+            _log.error("Cannot verify: SDK path not set")
             raise RuntimeError(_ERR_NOT_INSTALLED)
+        _log.info(f"Starting QAIRT SDK verification at {self._sdk_path}")
         issues: list[str] = []
         if not self._sdk_path.exists():
-            issues.append(f"SDK path does not exist: {self._sdk_path}")
-        issues.extend(f"Missing system package: {pkg}" for pkg in self.check_system_deps())
+            issue = f"SDK path does not exist: {self._sdk_path}"
+            issues.append(issue)
+            _log.error(issue)
+        else:
+            _log.debug(f"SDK path exists: {self._sdk_path}")
+        missing_deps = self.check_system_deps()
+        issues.extend(f"Missing system package: {pkg}" for pkg in missing_deps)
         if shutil.which("dpkg"):
+            _log.debug("Running qairt-vm --inspect on Ubuntu")
             env = {**os.environ, "QAIRT_SDK_ROOT": str(self._sdk_path)}
             result = subprocess.run(  # noqa: S603
                 [_QAIRT_VM, "--inspect"],
@@ -145,12 +176,22 @@ class QairtSDKManager:
                 check=False,
             )
             if result.returncode != 0:
-                issues.append(f"qairt-vm --inspect failed (exit {result.returncode})")
+                issue = f"qairt-vm --inspect failed (exit {result.returncode})"
+                issues.append(issue)
+                _log.warning(issue)
+            else:
+                _log.debug("qairt-vm --inspect passed")
         else:
-            issues.append(
+            issue = (
                 "QAIRT SDK is officially supported on Ubuntu only; "
                 "--inspect skipped on this system."
             )
+            issues.append(issue)
+            _log.warning(issue)
+        if issues:
+            _log.warning(f"Verification found {len(issues)} issue(s)")
+        else:
+            _log.info("Verification passed: no issues found")
         return issues
 
     def clean(self) -> Path:
@@ -163,9 +204,12 @@ class QairtSDKManager:
             RuntimeError: If SDK path is not configured.
         """
         if self._sdk_path is None:
+            _log.error("Cannot clean: SDK path not configured")
             raise RuntimeError(_ERR_NOT_INSTALLED_M2A)
         path = self._sdk_path
+        _log.info(f"Removing QAIRT SDK at {path}")
         shutil.rmtree(path, ignore_errors=True)
+        _log.debug(f"SDK directory removed: {path}")
         self._sdk_path = None
         return path
 
@@ -175,6 +219,12 @@ class QairtSDKManager:
         """Glob install_dir/qairt/<version>.* and return the first match."""
         base = self._install_dir / "qairt"
         if not base.exists():
+            _log.debug(f"QAIRT base directory does not exist: {base}")
             return None
         matches = sorted(base.glob(f"{self._sdk_version}.*"))
-        return matches[0] if matches else None
+        if matches:
+            path = matches[0]
+            _log.debug(f"Found SDK path: {path}")
+            return path
+        _log.warning(f"No SDK path found matching version {self._sdk_version} in {base}")
+        return None

--- a/src/moment_to_action/qairt/_manager.py
+++ b/src/moment_to_action/qairt/_manager.py
@@ -18,6 +18,7 @@ _QAIRT_VM = Path(sys.executable).parent / "qairt-vm"
 _ERR_NOT_INSTALLED = "SDK not installed; run 'm2a qairt install' first"
 _ERR_NOT_INSTALLED_M2A = "SDK not installed via m2a"
 _ERR_FETCH_PATH = "fetch succeeded but SDK path not found under install dir"
+_ERR_ALREADY_INSTALLED = "QAIRT SDK {version} already installed at {path}"
 
 
 class QairtSDKManager:
@@ -93,8 +94,11 @@ class QairtSDKManager:
                 capture output (useful for --json mode).
 
         Raises:
-            RuntimeError: If the fetch fails or the extracted path cannot be found.
+            RuntimeError: If already installed, fetch fails, or extracted path cannot be found.
         """
+        if self.is_available:
+            msg = _ERR_ALREADY_INSTALLED.format(version=self.installed_version, path=self._sdk_path)
+            raise RuntimeError(msg)
         result = subprocess.run(  # noqa: S603
             [_QAIRT_VM, "fetch", "--version", self._sdk_version, "--dir", str(self._install_dir)],
             capture_output=not stream,

--- a/src/moment_to_action/qairt/_manager.py
+++ b/src/moment_to_action/qairt/_manager.py
@@ -28,9 +28,17 @@ class QairtSDKManager:
     """Manages the QAIRT SDK installation for this application."""
 
     def __init__(self, sdk_path: Path | None, sdk_version: str, install_dir: Path) -> None:
+        """Initialize the QAIRT SDK manager.
+
+        Args:
+            sdk_path: Path to the installed SDK, or None if not yet installed.
+            sdk_version: Version string to fetch (e.g. "2.45.0").
+            install_dir: Directory where SDK will be installed.
+        """
         self._sdk_path = sdk_path
         self._sdk_version = sdk_version
         self._install_dir = install_dir
+
         _log.debug(
             f"Initialized QairtSDKManager: version={sdk_version}, "
             f"install_dir={install_dir}, sdk_path={sdk_path}"
@@ -133,6 +141,7 @@ class QairtSDKManager:
             _log.error(_ERR_FETCH_PATH)
             raise RuntimeError(_ERR_FETCH_PATH)
         self._sdk_path = path
+        self._cleanup_zip_files()
         _log.info(f"Successfully installed QAIRT SDK {self._sdk_version} at {path}")
         return path
 
@@ -214,6 +223,15 @@ class QairtSDKManager:
         return path
 
     # --- Internal ---
+
+    def _cleanup_zip_files(self) -> None:
+        """Remove any .zip files from the install directory after extraction."""
+        for zip_file in self._install_dir.glob("*.zip"):
+            try:
+                _log.debug(f"Removing zip file: {zip_file}")
+                zip_file.unlink()
+            except OSError as e:  # noqa: PERF203
+                _log.warning(f"Failed to remove zip file {zip_file}: {e}")
 
     def _find_sdk_path(self) -> Path | None:
         """Glob install_dir/qairt/<version>.* and return the first match."""

--- a/src/moment_to_action/utils/schemas.py
+++ b/src/moment_to_action/utils/schemas.py
@@ -1,0 +1,32 @@
+"""Utilites for working with pydantic schemas."""
+
+from __future__ import annotations
+
+import typing as t
+
+from pydantic import BaseModel
+
+_T = t.TypeVar("_T", bound=BaseModel)
+
+
+def update_frozen(model: _T, **updates: t.Any) -> _T:
+    """Update a pydantic model, returning a copy.
+
+    VERY useful for frozen models.
+
+    Args:
+        model: Model to update.
+        updates: key=value pairs to update.
+
+    Returns:
+        The updated model.
+
+    Raises:
+        ValidationError: invalid value in updates.
+    """
+    # Create new data; updates win here
+    # https://docs.python.org/3/library/stdtypes.html#dict.values
+    data = model.model_dump() | updates
+
+    # Validate new data
+    return type(model).model_validate(data)

--- a/tests/unit/cli/commands/qairt/test_cmd_qairt_clean.py
+++ b/tests/unit/cli/commands/qairt/test_cmd_qairt_clean.py
@@ -1,0 +1,126 @@
+"""Unit tests for m2a qairt clean command."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner, Result
+
+from moment_to_action.config import AppConfig
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _patched_pm(tmp_path: Path) -> MagicMock:
+    mock_pm = MagicMock()
+    mock_pm.data.data_dir = tmp_path
+    mock_pm.app_config_file = tmp_path / "config.json"
+    return mock_pm
+
+
+def _invoke(args: list[str], tmp_path: Path, mgr: MagicMock, stdin: str | None = None) -> Result:
+    from moment_to_action._cli import cli
+
+    with patch("moment_to_action._cli.init_logging"):
+        with patch("moment_to_action._cli.PathManager", return_value=_patched_pm(tmp_path)):
+            with patch("moment_to_action._cli.load_config", return_value=AppConfig()):
+                with patch(
+                    "moment_to_action._cli.commands.cmd_qairt.cmd_clean.QairtSDKManager.from_app_config",
+                    return_value=mgr,
+                ):
+                    return CliRunner().invoke(cli, ["qairt", "clean", *args], input=stdin)
+
+
+@pytest.mark.unit
+class TestQairtCleanCommand:
+    """Tests for the qairt clean subcommand."""
+
+    def test_not_installed_shows_error(self, tmp_path: Path) -> None:
+        """RuntimeError from clean is surfaced as a Click error."""
+        mgr = MagicMock()
+        mgr.clean.side_effect = RuntimeError("SDK not installed via m2a")
+        result = _invoke(["--force"], tmp_path, mgr)
+        assert result.exit_code != 0
+        assert "not installed" in result.output
+
+    def test_force_skips_confirmation(self, tmp_path: Path) -> None:
+        """--force skips the confirmation prompt and proceeds."""
+        removed = tmp_path / "2.45.0.24"
+        mgr = MagicMock()
+        mgr.clean.return_value = removed
+        result = _invoke(["--force"], tmp_path, mgr)
+        assert result.exit_code == 0
+        mgr.clean.assert_called_once()
+
+    def test_confirm_yes_proceeds(self, tmp_path: Path) -> None:
+        """Confirmation 'y' proceeds with removal."""
+        removed = tmp_path / "2.45.0.24"
+        mgr = MagicMock()
+        mgr.clean.return_value = removed
+        result = _invoke([], tmp_path, mgr, stdin="y\n")
+        assert result.exit_code == 0
+        mgr.clean.assert_called_once()
+
+    def test_confirm_no_cancels(self, tmp_path: Path) -> None:
+        """Confirmation 'n' cancels without removing."""
+        mgr = MagicMock()
+        result = _invoke([], tmp_path, mgr, stdin="n\n")
+        assert result.exit_code == 0
+        assert "cancelled" in result.output.lower()
+        mgr.clean.assert_not_called()
+
+    def test_json_skips_confirmation_and_outputs_json(self, tmp_path: Path) -> None:
+        """--json skips confirmation and outputs valid JSON."""
+        removed = tmp_path / "2.45.0.24"
+        mgr = MagicMock()
+        mgr.clean.return_value = removed
+        result = _invoke(["--json"], tmp_path, mgr)
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "removed" in data
+        assert data["removed"] == str(removed)
+        mgr.clean.assert_called_once()
+
+    def test_eof_in_non_interactive_proceeds(self, tmp_path: Path) -> None:
+        """EOFError in non-interactive mode is treated as confirmation and proceeds."""
+        removed = tmp_path / "2.45.0.24"
+        mgr = MagicMock()
+        mgr.clean.return_value = removed
+        result = _invoke([], tmp_path, mgr, stdin="")
+        assert result.exit_code == 0
+        mgr.clean.assert_called_once()
+
+    def test_config_cleared_after_clean(self, tmp_path: Path) -> None:
+        """After clean, qairt_sdk_path is set to None in saved config."""
+        removed = tmp_path / "2.45.0.24"
+        sdk_path = removed
+        config = AppConfig(qairt_sdk_path=sdk_path)
+        mgr = MagicMock()
+        mgr.clean.return_value = removed
+
+        from moment_to_action._cli import cli
+
+        saved_configs: list[AppConfig] = []
+
+        def _save(cfg: AppConfig, _path: object) -> None:
+            saved_configs.append(cfg)
+
+        with patch("moment_to_action._cli.init_logging"):
+            with patch("moment_to_action._cli.PathManager", return_value=_patched_pm(tmp_path)):
+                with patch("moment_to_action._cli.load_config", return_value=config):
+                    with patch(
+                        "moment_to_action._cli.commands.cmd_qairt.cmd_clean.QairtSDKManager.from_app_config",
+                        return_value=mgr,
+                    ):
+                        with patch(
+                            "moment_to_action._cli.commands.cmd_qairt.cmd_clean.save_config",
+                            side_effect=_save,
+                        ):
+                            CliRunner().invoke(cli, ["qairt", "clean", "--force"])
+
+        assert saved_configs, "save_config was not called"
+        assert saved_configs[-1].qairt_sdk_path is None

--- a/tests/unit/cli/commands/qairt/test_cmd_qairt_info.py
+++ b/tests/unit/cli/commands/qairt/test_cmd_qairt_info.py
@@ -1,0 +1,121 @@
+"""Unit tests for m2a qairt info command."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner, Result
+
+from moment_to_action.config import AppConfig
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _patched_pm(tmp_path: Path) -> MagicMock:
+    mock_pm = MagicMock()
+    mock_pm.data.data_dir = tmp_path
+    mock_pm.app_config_file = tmp_path / "config.json"
+    return mock_pm
+
+
+def _invoke(args: list[str], tmp_path: Path, mgr: MagicMock) -> Result:
+    from moment_to_action._cli import cli
+
+    with patch("moment_to_action._cli.init_logging"):
+        with patch("moment_to_action._cli.PathManager", return_value=_patched_pm(tmp_path)):
+            with patch("moment_to_action._cli.load_config", return_value=AppConfig()):
+                with patch(
+                    "moment_to_action._cli.commands.cmd_qairt.cmd_info.QairtSDKManager.from_app_config",
+                    return_value=mgr,
+                ):
+                    return CliRunner().invoke(cli, ["qairt", "info", *args])
+
+
+def _make_mgr(
+    *,
+    configured_version: str = "2.45.0",
+    installed_version: str | None = None,
+    path: Path | None = None,
+    available: bool = False,
+) -> MagicMock:
+    mgr = MagicMock()
+    mgr.configured_version = configured_version
+    mgr.installed_version = installed_version
+    mgr.path = path
+    mgr.is_available = available
+    return mgr
+
+
+@pytest.mark.unit
+class TestQairtInfoCommand:
+    """Tests for the qairt info subcommand."""
+
+    def test_not_installed_exits_zero(self, tmp_path: Path) -> None:
+        """Command exits 0 even when SDK is not installed."""
+        mgr = _make_mgr()
+        result = _invoke([], tmp_path, mgr)
+        assert result.exit_code == 0
+
+    def test_not_installed_shows_not_installed(self, tmp_path: Path) -> None:
+        """Output contains 'not installed' indicator when SDK is absent."""
+        mgr = _make_mgr()
+        result = _invoke([], tmp_path, mgr)
+        assert result.exit_code == 0
+        assert "not installed" in result.output.lower()
+
+    def test_installed_shows_version_and_path(self, tmp_path: Path) -> None:
+        """Output contains version and path indicator when SDK is installed."""
+        sdk = tmp_path / "2.45.0.24"
+        mgr = _make_mgr(
+            installed_version="2.45.0.24",
+            path=sdk,
+            available=True,
+        )
+        result = _invoke([], tmp_path, mgr)
+        assert result.exit_code == 0
+        assert "2.45.0.24" in result.output
+
+    def test_json_output_valid_json(self, tmp_path: Path) -> None:
+        """--json flag produces valid JSON."""
+        mgr = _make_mgr()
+        result = _invoke(["--json"], tmp_path, mgr)
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert isinstance(data, dict)
+
+    def test_json_output_has_expected_keys(self, tmp_path: Path) -> None:
+        """JSON output contains all expected keys."""
+        sdk = tmp_path / "2.45.0.24"
+        mgr = _make_mgr(
+            configured_version="2.45.0",
+            installed_version="2.45.0.24",
+            path=sdk,
+            available=True,
+        )
+        result = _invoke(["--json"], tmp_path, mgr)
+        data = json.loads(result.output)
+        assert "configured_version" in data
+        assert "installed_version" in data
+        assert "path" in data
+        assert "available" in data
+
+    def test_json_not_installed_path_is_null(self, tmp_path: Path) -> None:
+        """JSON output has null path and available=false when SDK not installed."""
+        mgr = _make_mgr()
+        result = _invoke(["--json"], tmp_path, mgr)
+        data = json.loads(result.output)
+        assert data["path"] is None
+        assert data["available"] is False
+
+    def test_json_installed_path_is_string(self, tmp_path: Path) -> None:
+        """JSON output has string path and available=true when SDK is installed."""
+        sdk = tmp_path / "2.45.0.24"
+        mgr = _make_mgr(path=sdk, available=True, installed_version="2.45.0.24")
+        result = _invoke(["--json"], tmp_path, mgr)
+        data = json.loads(result.output)
+        assert data["path"] == str(sdk)
+        assert data["available"] is True

--- a/tests/unit/cli/commands/qairt/test_cmd_qairt_install.py
+++ b/tests/unit/cli/commands/qairt/test_cmd_qairt_install.py
@@ -22,7 +22,9 @@ def _patched_pm(tmp_path: Path) -> MagicMock:
     return mock_pm
 
 
-def _invoke(args: list[str], tmp_path: Path, mgr: MagicMock) -> Result:
+def _invoke(
+    args: list[str], tmp_path: Path, mgr: MagicMock, input_text: str | None = None
+) -> Result:
     from moment_to_action._cli import cli
 
     with patch("moment_to_action._cli.init_logging"):
@@ -32,7 +34,8 @@ def _invoke(args: list[str], tmp_path: Path, mgr: MagicMock) -> Result:
                     "moment_to_action._cli.commands.cmd_qairt.cmd_install.QairtSDKManager.from_app_config",
                     return_value=mgr,
                 ):
-                    return CliRunner().invoke(cli, ["qairt", "install", *args])
+                    runner = CliRunner()
+                    return runner.invoke(cli, ["qairt", "install", *args], input=input_text)
 
 
 @pytest.mark.unit
@@ -97,3 +100,33 @@ class TestQairtInstallCommand:
         assert "path" in data
         assert "version" in data
         assert data["version"] == "2.45.0.24"
+
+    def test_already_installed_user_confirms_reinstall(self, tmp_path: Path) -> None:
+        """When already installed and user confirms, clean then reinstall."""
+        sdk_path = tmp_path / "qairt" / "2.45.0.24"
+        sdk_path.mkdir(parents=True)
+        mgr = MagicMock()
+        mgr.check_system_deps.return_value = []
+        error_msg = f"QAIRT SDK 2.45.0.24 already installed at {sdk_path}"
+        mgr.install.side_effect = [
+            RuntimeError(error_msg),
+            sdk_path,  # second call succeeds
+        ]
+        mgr.installed_version = "2.45.0.24"
+        mgr.verify.return_value = []
+        result = _invoke([], tmp_path, mgr, input_text="y\n")
+        assert result.exit_code == 0
+        mgr.clean.assert_called_once()
+        assert mgr.install.call_count == 2
+
+    def test_already_installed_user_declines_reinstall(self, tmp_path: Path) -> None:
+        """When already installed and user declines, abort without reinstalling."""
+        sdk_path = tmp_path / "qairt" / "2.45.0.24"
+        sdk_path.mkdir(parents=True)
+        mgr = MagicMock()
+        mgr.check_system_deps.return_value = []
+        error_msg = f"QAIRT SDK 2.45.0.24 already installed at {sdk_path}"
+        mgr.install.side_effect = RuntimeError(error_msg)
+        result = _invoke([], tmp_path, mgr, input_text="n\n")
+        assert result.exit_code != 0
+        mgr.clean.assert_not_called()

--- a/tests/unit/cli/commands/qairt/test_cmd_qairt_install.py
+++ b/tests/unit/cli/commands/qairt/test_cmd_qairt_install.py
@@ -1,0 +1,99 @@
+"""Unit tests for m2a qairt install command."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner, Result
+
+from moment_to_action.config import AppConfig
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _patched_pm(tmp_path: Path) -> MagicMock:
+    mock_pm = MagicMock()
+    mock_pm.data.data_dir = tmp_path
+    mock_pm.app_config_file = tmp_path / "config.json"
+    return mock_pm
+
+
+def _invoke(args: list[str], tmp_path: Path, mgr: MagicMock) -> Result:
+    from moment_to_action._cli import cli
+
+    with patch("moment_to_action._cli.init_logging"):
+        with patch("moment_to_action._cli.PathManager", return_value=_patched_pm(tmp_path)):
+            with patch("moment_to_action._cli.load_config", return_value=AppConfig()):
+                with patch(
+                    "moment_to_action._cli.commands.cmd_qairt.cmd_install.QairtSDKManager.from_app_config",
+                    return_value=mgr,
+                ):
+                    return CliRunner().invoke(cli, ["qairt", "install", *args])
+
+
+@pytest.mark.unit
+class TestQairtInstallCommand:
+    """Tests for the qairt install subcommand."""
+
+    def test_missing_deps_aborts(self, tmp_path: Path) -> None:
+        """Missing system deps aborts before attempting install."""
+        mgr = MagicMock()
+        mgr.check_system_deps.return_value = ["libgl1", "clang"]
+        result = _invoke([], tmp_path, mgr)
+        assert result.exit_code != 0
+        mgr.install.assert_not_called()
+
+    def test_install_failure_raises_click_exception(self, tmp_path: Path) -> None:
+        """RuntimeError from install is surfaced as a Click error."""
+        mgr = MagicMock()
+        mgr.check_system_deps.return_value = []
+        mgr.install.side_effect = RuntimeError("fetch failed (exit 1)")
+        result = _invoke([], tmp_path, mgr)
+        assert result.exit_code != 0
+        assert "fetch failed" in result.output
+
+    def test_happy_path_saves_config_and_calls_verify(self, tmp_path: Path) -> None:
+        """Successful install saves config and runs verify."""
+        sdk_path = tmp_path / "qairt" / "2.45.0.24"
+        sdk_path.mkdir(parents=True)
+        mgr = MagicMock()
+        mgr.check_system_deps.return_value = []
+        mgr.install.return_value = sdk_path
+        mgr.installed_version = "2.45.0.24"
+        mgr.verify.return_value = []
+        result = _invoke([], tmp_path, mgr)
+        assert result.exit_code == 0
+        mgr.install.assert_called_once()
+        mgr.verify.assert_called_once_with(stream=True)
+
+    def test_verify_warnings_are_logged(self, tmp_path: Path) -> None:
+        """Verify warnings are logged after a successful install."""
+        sdk_path = tmp_path / "qairt" / "2.45.0.24"
+        sdk_path.mkdir(parents=True)
+        mgr = MagicMock()
+        mgr.check_system_deps.return_value = []
+        mgr.install.return_value = sdk_path
+        mgr.installed_version = "2.45.0.24"
+        mgr.verify.return_value = ["Missing system package: clang"]
+        result = _invoke([], tmp_path, mgr)
+        assert result.exit_code == 0
+
+    def test_json_output_contains_path_and_version(self, tmp_path: Path) -> None:
+        """--json flag outputs valid JSON with path and version keys."""
+        sdk_path = tmp_path / "qairt" / "2.45.0.24"
+        sdk_path.mkdir(parents=True)
+        mgr = MagicMock()
+        mgr.check_system_deps.return_value = []
+        mgr.install.return_value = sdk_path
+        mgr.installed_version = "2.45.0.24"
+        mgr.verify.return_value = []
+        result = _invoke(["--json"], tmp_path, mgr)
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "path" in data
+        assert "version" in data
+        assert data["version"] == "2.45.0.24"

--- a/tests/unit/cli/commands/qairt/test_cmd_qairt_verify.py
+++ b/tests/unit/cli/commands/qairt/test_cmd_qairt_verify.py
@@ -1,0 +1,68 @@
+"""Unit tests for m2a qairt verify command."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner, Result
+
+from moment_to_action.config import AppConfig
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _patched_pm(tmp_path: Path) -> MagicMock:
+    mock_pm = MagicMock()
+    mock_pm.data.data_dir = tmp_path
+    mock_pm.app_config_file = tmp_path / "config.json"
+    return mock_pm
+
+
+def _invoke(args: list[str], tmp_path: Path, mgr: MagicMock) -> Result:
+    from moment_to_action._cli import cli
+
+    with patch("moment_to_action._cli.init_logging"):
+        with patch("moment_to_action._cli.PathManager", return_value=_patched_pm(tmp_path)):
+            with patch("moment_to_action._cli.load_config", return_value=AppConfig()):
+                with patch(
+                    "moment_to_action._cli.commands.cmd_qairt.cmd_verify.QairtSDKManager.from_app_config",
+                    return_value=mgr,
+                ):
+                    return CliRunner().invoke(cli, ["qairt", "verify", *args])
+
+
+@pytest.mark.unit
+class TestQairtVerifyCommand:
+    """Tests for the qairt verify subcommand."""
+
+    def test_not_installed_shows_error(self, tmp_path: Path) -> None:
+        """RuntimeError from verify is surfaced as a Click error."""
+        mgr = MagicMock()
+        mgr.verify.side_effect = RuntimeError("SDK not installed")
+        result = _invoke([], tmp_path, mgr)
+        assert result.exit_code != 0
+        assert "not installed" in result.output
+
+    def test_verify_success_exits_zero(self, tmp_path: Path) -> None:
+        """No issues from verify exits 0."""
+        mgr = MagicMock()
+        mgr.verify.return_value = []
+        result = _invoke([], tmp_path, mgr)
+        assert result.exit_code == 0
+
+    def test_verify_exits_one_when_issues(self, tmp_path: Path) -> None:
+        """Issues returned by verify cause exit code 1."""
+        mgr = MagicMock()
+        mgr.verify.return_value = ["Missing system package: clang"]
+        result = _invoke([], tmp_path, mgr)
+        assert result.exit_code == 1
+
+    def test_verify_called_with_stream_true(self, tmp_path: Path) -> None:
+        """Verify calls mgr.verify(stream=True)."""
+        mgr = MagicMock()
+        mgr.verify.return_value = []
+        _invoke([], tmp_path, mgr)
+        mgr.verify.assert_called_once_with(stream=True)

--- a/tests/unit/qairt/test_deps.py
+++ b/tests/unit/qairt/test_deps.py
@@ -1,0 +1,148 @@
+"""Unit tests for qairt._deps system dependency checking."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+
+from moment_to_action.qairt._deps import (
+    _APT_DEPS,
+    _DNF_DEPS,
+    _missing_apt,
+    _missing_dnf,
+    check_system_deps,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+def _make_run(missing: set[str]) -> Callable[..., object]:
+    """Return a subprocess.run side-effect that reports packages in missing as absent."""
+
+    def _run(cmd: list[str], **_: object) -> object:
+        pkg = cmd[-1]
+
+        class _R:
+            returncode = 1 if pkg in missing else 0
+
+        return _R()
+
+    return _run
+
+
+@pytest.mark.unit
+class TestMissingApt:
+    """Tests for _missing_apt."""
+
+    def test_all_present_returns_empty(self) -> None:
+        """Returns empty list when all packages are installed."""
+        with patch("moment_to_action.qairt._deps.subprocess.run", side_effect=_make_run(set())):
+            assert _missing_apt(_APT_DEPS) == []
+
+    def test_missing_packages_returned(self) -> None:
+        """Returns list of packages that are not installed."""
+        missing = {"clang", "unzip"}
+        with patch("moment_to_action.qairt._deps.subprocess.run", side_effect=_make_run(missing)):
+            result = _missing_apt(_APT_DEPS)
+        assert set(result) == missing
+
+    def test_uses_dpkg_s(self) -> None:
+        """Checks package presence using dpkg -s."""
+        calls: list[list[str]] = []
+
+        def _run(cmd: list[str], **_: object) -> object:
+            calls.append(cmd)
+
+            class _R:
+                returncode = 0
+
+            return _R()
+
+        with patch("moment_to_action.qairt._deps.subprocess.run", side_effect=_run):
+            _missing_apt(["clang"])
+
+        assert calls[0][:2] == ["dpkg", "-s"]
+
+
+@pytest.mark.unit
+class TestMissingDnf:
+    """Tests for _missing_dnf."""
+
+    def test_all_present_returns_empty(self) -> None:
+        """Returns empty list when all packages are installed."""
+        with patch("moment_to_action.qairt._deps.subprocess.run", side_effect=_make_run(set())):
+            assert _missing_dnf(_DNF_DEPS) == []
+
+    def test_missing_packages_returned(self) -> None:
+        """Returns list of packages that are not installed."""
+        missing = {"clang", "wget2"}
+        with patch("moment_to_action.qairt._deps.subprocess.run", side_effect=_make_run(missing)):
+            result = _missing_dnf(_DNF_DEPS)
+        assert set(result) == missing
+
+    def test_uses_rpm_q(self) -> None:
+        """Checks package presence using rpm -q."""
+        calls: list[list[str]] = []
+
+        def _run(cmd: list[str], **_: object) -> object:
+            calls.append(cmd)
+
+            class _R:
+                returncode = 0
+
+            return _R()
+
+        with patch("moment_to_action.qairt._deps.subprocess.run", side_effect=_run):
+            _missing_dnf(["clang"])
+
+        assert calls[0][:2] == ["rpm", "-q"]
+
+
+@pytest.mark.unit
+class TestCheckSystemDeps:
+    """Tests for check_system_deps."""
+
+    def test_apt_path_used_when_dpkg_present(self) -> None:
+        """Uses apt checking when dpkg is available."""
+        with patch("moment_to_action.qairt._deps.shutil.which", return_value="/usr/bin/dpkg"):
+            with patch(
+                "moment_to_action.qairt._deps._missing_apt", return_value=["libgl1"]
+            ) as mock_apt:
+                result = check_system_deps()
+        mock_apt.assert_called_once()
+        assert result == ["libgl1"]
+
+    def test_dnf_path_used_when_only_rpm_present(self) -> None:
+        """Uses rpm checking when dpkg is absent but rpm is available."""
+
+        def _which(name: str) -> str | None:
+            return "/usr/bin/rpm" if name == "rpm" else None
+
+        with patch("moment_to_action.qairt._deps.shutil.which", side_effect=_which):
+            with patch("moment_to_action.qairt._deps._missing_dnf", return_value=[]) as mock_dnf:
+                result = check_system_deps()
+        mock_dnf.assert_called_once()
+        assert result == []
+
+    def test_unknown_distro_returns_empty_and_warns(self) -> None:
+        """Returns empty list and logs warning when neither dpkg nor rpm is available."""
+        with patch("moment_to_action.qairt._deps.shutil.which", return_value=None):
+            with patch("moment_to_action.qairt._deps._LOG") as mock_log:
+                result = check_system_deps()
+        assert result == []
+        mock_log.warning.assert_called_once()
+
+    def test_rpm_distro_warns_about_support(self) -> None:
+        """Logs a support warning on rpm-based systems."""
+
+        def _which(name: str) -> str | None:
+            return "/usr/bin/rpm" if name == "rpm" else None
+
+        with patch("moment_to_action.qairt._deps.shutil.which", side_effect=_which):
+            with patch("moment_to_action.qairt._deps._missing_dnf", return_value=[]):
+                with patch("moment_to_action.qairt._deps._LOG") as mock_log:
+                    check_system_deps()
+        mock_log.warning.assert_called_once()

--- a/tests/unit/qairt/test_manager.py
+++ b/tests/unit/qairt/test_manager.py
@@ -1,0 +1,350 @@
+"""Unit tests for QairtSDKManager."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from moment_to_action.config import AppConfig
+from moment_to_action.qairt._manager import QairtSDKManager
+
+
+def _make_mgr(
+    sdk_path: Path | None = None,
+    sdk_version: str = "2.45.0",
+    install_dir: Path | None = None,
+    tmp_path: Path | None = None,
+) -> QairtSDKManager:
+    if install_dir is None:
+        install_dir = tmp_path or Path("/tmp/test_install")
+    return QairtSDKManager(sdk_path=sdk_path, sdk_version=sdk_version, install_dir=install_dir)
+
+
+@pytest.mark.unit
+class TestQairtSDKManagerFromAppConfig:
+    """Tests for QairtSDKManager.from_app_config."""
+
+    def test_from_app_config(self, tmp_path: Path) -> None:
+        """from_app_config populates sdk_path and sdk_version from config."""
+        config = AppConfig(qairt_sdk_path=tmp_path / "sdk", qairt_sdk_version="2.44.0")
+        mock_pm = MagicMock()
+        mock_pm.data.data_dir = tmp_path
+        mgr = QairtSDKManager.from_app_config(config, mock_pm)
+        assert mgr.path == tmp_path / "sdk"
+        assert mgr.configured_version == "2.44.0"
+
+    def test_from_app_config_no_path(self, tmp_path: Path) -> None:
+        """from_app_config with no qairt_sdk_path yields path=None."""
+        config = AppConfig()
+        mock_pm = MagicMock()
+        mock_pm.data.data_dir = tmp_path
+        mgr = QairtSDKManager.from_app_config(config, mock_pm)
+        assert mgr.path is None
+
+
+@pytest.mark.unit
+class TestQairtSDKManagerProperties:
+    """Tests for QairtSDKManager read-only properties."""
+
+    def test_is_available_false_when_path_none(self) -> None:
+        """is_available is False when no path configured."""
+        mgr = _make_mgr(sdk_path=None)
+        assert mgr.is_available is False
+
+    def test_is_available_false_when_dir_missing(self, tmp_path: Path) -> None:
+        """is_available is False when configured path does not exist on disk."""
+        mgr = _make_mgr(sdk_path=tmp_path / "nonexistent")
+        assert mgr.is_available is False
+
+    def test_is_available_true_when_dir_exists(self, tmp_path: Path) -> None:
+        """is_available is True when configured path exists on disk."""
+        sdk = tmp_path / "2.45.0.24"
+        sdk.mkdir()
+        mgr = _make_mgr(sdk_path=sdk)
+        assert mgr.is_available is True
+
+    def test_path_returns_configured(self, tmp_path: Path) -> None:
+        """Path property returns the configured SDK path."""
+        p = tmp_path / "sdk"
+        mgr = _make_mgr(sdk_path=p)
+        assert mgr.path == p
+
+    def test_configured_version(self) -> None:
+        """configured_version returns the version string from construction."""
+        mgr = _make_mgr(sdk_version="2.44.0")
+        assert mgr.configured_version == "2.44.0"
+
+    def test_installed_version_none_when_unavailable(self) -> None:
+        """installed_version is None when SDK not configured."""
+        mgr = _make_mgr(sdk_path=None)
+        assert mgr.installed_version is None
+
+    def test_installed_version_none_when_dir_missing(self, tmp_path: Path) -> None:
+        """installed_version is None when configured path does not exist."""
+        mgr = _make_mgr(sdk_path=tmp_path / "nonexistent")
+        assert mgr.installed_version is None
+
+    def test_installed_version_from_path_name(self, tmp_path: Path) -> None:
+        """installed_version is derived from the directory name."""
+        sdk = tmp_path / "2.45.0.24"
+        sdk.mkdir()
+        mgr = _make_mgr(sdk_path=sdk)
+        assert mgr.installed_version == "2.45.0.24"
+
+
+@pytest.mark.unit
+class TestQairtSDKManagerConfigureEnv:
+    """Tests for QairtSDKManager.configure_env."""
+
+    def test_configure_env_raises_when_no_path(self) -> None:
+        """configure_env raises RuntimeError when SDK not installed."""
+        mgr = _make_mgr(sdk_path=None)
+        with pytest.raises(RuntimeError, match="not installed"):
+            mgr.configure_env()
+
+    def test_configure_env_sets_env_var(self, tmp_path: Path) -> None:
+        """configure_env sets QAIRT_SDK_ROOT to the installed path."""
+        sdk = tmp_path / "2.45.0.24"
+        sdk.mkdir()
+        mgr = _make_mgr(sdk_path=sdk)
+        old = os.environ.pop("QAIRT_SDK_ROOT", None)
+        try:
+            mgr.configure_env()
+            assert os.environ["QAIRT_SDK_ROOT"] == str(sdk)
+        finally:
+            if old is None:
+                os.environ.pop("QAIRT_SDK_ROOT", None)
+            else:
+                os.environ["QAIRT_SDK_ROOT"] = old
+
+
+@pytest.mark.unit
+class TestQairtSDKManagerCheckDeps:
+    """Tests for QairtSDKManager.check_system_deps."""
+
+    def test_delegates_to_deps_module(self) -> None:
+        """check_system_deps delegates to the _deps.check_system_deps function."""
+        mgr = _make_mgr()
+        with patch(
+            "moment_to_action.qairt._manager.QairtSDKManager.check_system_deps",
+            return_value=["clang"],
+        ):
+            result = mgr.check_system_deps()
+        assert result == ["clang"]
+
+    def test_returns_empty_when_all_deps_present(self) -> None:
+        """Returns empty list when check_system_deps reports no missing packages."""
+        mgr = _make_mgr()
+        with patch("moment_to_action.qairt._deps.check_system_deps", return_value=[]):
+            result = mgr.check_system_deps()
+        assert result == []
+
+
+@pytest.mark.unit
+class TestQairtSDKManagerInstall:
+    """Tests for QairtSDKManager.install."""
+
+    def test_install_success(self, tmp_path: Path) -> None:
+        """Install returns the extracted SDK path on success."""
+        sdk = tmp_path / "qairt" / "2.45.0.24"
+        sdk.mkdir(parents=True)
+        mgr = _make_mgr(install_dir=tmp_path)
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        with patch("moment_to_action.qairt._manager.subprocess.run", return_value=mock_result):
+            path = mgr.install(stream=False)
+
+        assert path == sdk
+        assert mgr.path == sdk
+
+    def test_install_calls_fetch_with_correct_args(self, tmp_path: Path) -> None:
+        """Install invokes qairt-vm fetch with version and dir flags."""
+        sdk = tmp_path / "qairt" / "2.45.0.24"
+        sdk.mkdir(parents=True)
+        mgr = _make_mgr(sdk_version="2.45.0", install_dir=tmp_path)
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        with patch(
+            "moment_to_action.qairt._manager.subprocess.run", return_value=mock_result
+        ) as mock_run:
+            mgr.install(stream=False)
+
+        args = mock_run.call_args[0][0]
+        assert "fetch" in args
+        assert "--version" in args
+        assert "2.45.0" in args
+        assert "--dir" in args
+        assert str(tmp_path) in args
+
+    def test_install_raises_on_nonzero_returncode(self, tmp_path: Path) -> None:
+        """Install raises RuntimeError when qairt-vm exits non-zero."""
+        mgr = _make_mgr(install_dir=tmp_path)
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        with patch("moment_to_action.qairt._manager.subprocess.run", return_value=mock_result):
+            with pytest.raises(RuntimeError, match="fetch failed"):
+                mgr.install(stream=False)
+
+    def test_install_raises_when_path_not_found(self, tmp_path: Path) -> None:
+        """Install raises RuntimeError when extracted path cannot be found."""
+        mgr = _make_mgr(install_dir=tmp_path)
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        with patch("moment_to_action.qairt._manager.subprocess.run", return_value=mock_result):
+            with pytest.raises(RuntimeError, match="SDK path not found"):
+                mgr.install(stream=False)
+
+    def test_install_stream_true_sets_capture_false(self, tmp_path: Path) -> None:
+        """Install with stream=True passes capture_output=False to subprocess."""
+        sdk = tmp_path / "qairt" / "2.45.0.24"
+        sdk.mkdir(parents=True)
+        mgr = _make_mgr(install_dir=tmp_path)
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        with patch(
+            "moment_to_action.qairt._manager.subprocess.run", return_value=mock_result
+        ) as mock_run:
+            mgr.install(stream=True)
+
+        assert mock_run.call_args.kwargs.get("capture_output") is False
+
+
+@pytest.mark.unit
+class TestQairtSDKManagerVerify:
+    """Tests for QairtSDKManager.verify."""
+
+    def test_verify_raises_when_no_path(self) -> None:
+        """Verify raises RuntimeError when SDK not installed."""
+        mgr = _make_mgr(sdk_path=None)
+        with pytest.raises(RuntimeError, match="not installed"):
+            mgr.verify()
+
+    def test_verify_returns_empty_on_ubuntu_when_ok(self, tmp_path: Path) -> None:
+        """On Ubuntu (dpkg present), returns empty list when all checks pass."""
+        sdk = tmp_path / "2.45.0.24"
+        sdk.mkdir()
+        mgr = _make_mgr(sdk_path=sdk)
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        with patch("moment_to_action.qairt._deps.check_system_deps", return_value=[]):
+            with patch(
+                "moment_to_action.qairt._manager.shutil.which", return_value="/usr/bin/dpkg"
+            ):
+                with patch(
+                    "moment_to_action.qairt._manager.subprocess.run", return_value=mock_result
+                ):
+                    result = mgr.verify(stream=False)
+        assert result == []
+
+    def test_verify_runs_inspect_on_ubuntu(self, tmp_path: Path) -> None:
+        """On Ubuntu, verify calls qairt-vm --inspect with QAIRT_SDK_ROOT set."""
+        sdk = tmp_path / "2.45.0.24"
+        sdk.mkdir()
+        mgr = _make_mgr(sdk_path=sdk)
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        with patch("moment_to_action.qairt._deps.check_system_deps", return_value=[]):
+            with patch(
+                "moment_to_action.qairt._manager.shutil.which", return_value="/usr/bin/dpkg"
+            ):
+                with patch(
+                    "moment_to_action.qairt._manager.subprocess.run", return_value=mock_result
+                ) as mock_run:
+                    mgr.verify(stream=False)
+        args = mock_run.call_args[0][0]
+        assert "--inspect" in args
+        env_passed = mock_run.call_args.kwargs["env"]
+        assert env_passed["QAIRT_SDK_ROOT"] == str(sdk)
+
+    def test_verify_inspect_failure_adds_warning(self, tmp_path: Path) -> None:
+        """Non-zero --inspect exit code is included as a warning."""
+        sdk = tmp_path / "2.45.0.24"
+        sdk.mkdir()
+        mgr = _make_mgr(sdk_path=sdk)
+        mock_result = MagicMock()
+        mock_result.returncode = 2
+        with patch("moment_to_action.qairt._deps.check_system_deps", return_value=[]):
+            with patch(
+                "moment_to_action.qairt._manager.shutil.which", return_value="/usr/bin/dpkg"
+            ):
+                with patch(
+                    "moment_to_action.qairt._manager.subprocess.run", return_value=mock_result
+                ):
+                    result = mgr.verify(stream=False)
+        assert any("--inspect failed" in w for w in result)
+
+    def test_verify_warns_unsupported_system(self, tmp_path: Path) -> None:
+        """On non-Ubuntu, verify adds an unsupported-system warning, skips inspect."""
+        sdk = tmp_path / "2.45.0.24"
+        sdk.mkdir()
+        mgr = _make_mgr(sdk_path=sdk)
+        with patch("moment_to_action.qairt._deps.check_system_deps", return_value=[]):
+            with patch("moment_to_action.qairt._manager.shutil.which", return_value=None):
+                result = mgr.verify(stream=False)
+        assert any("officially supported on Ubuntu" in w for w in result)
+
+    def test_verify_warns_when_path_missing(self, tmp_path: Path) -> None:
+        """Verify includes warning when configured SDK path does not exist on disk."""
+        sdk = tmp_path / "2.45.0.24"
+        mgr = _make_mgr(sdk_path=sdk)
+        with patch("moment_to_action.qairt._deps.check_system_deps", return_value=[]):
+            with patch("moment_to_action.qairt._manager.shutil.which", return_value=None):
+                result = mgr.verify(stream=False)
+        assert any("does not exist" in w for w in result)
+
+    def test_verify_warns_missing_deps(self, tmp_path: Path) -> None:
+        """Verify includes one warning per missing system package."""
+        sdk = tmp_path / "2.45.0.24"
+        sdk.mkdir()
+        mgr = _make_mgr(sdk_path=sdk)
+        with patch(
+            "moment_to_action.qairt._deps.check_system_deps", return_value=["clang", "curl"]
+        ):
+            with patch("moment_to_action.qairt._manager.shutil.which", return_value=None):
+                result = mgr.verify(stream=False)
+        pkg_warnings = [w for w in result if "Missing system package" in w]
+        assert len(pkg_warnings) == 2
+
+
+@pytest.mark.unit
+class TestQairtSDKManagerClean:
+    """Tests for QairtSDKManager.clean."""
+
+    def test_clean_raises_when_no_path(self) -> None:
+        """Clean raises RuntimeError when SDK not installed via m2a."""
+        mgr = _make_mgr(sdk_path=None)
+        with pytest.raises(RuntimeError, match="not installed"):
+            mgr.clean()
+
+    def test_clean_calls_rmtree(self, tmp_path: Path) -> None:
+        """Clean calls shutil.rmtree on the SDK directory."""
+        sdk = tmp_path / "2.45.0.24"
+        sdk.mkdir()
+        mgr = _make_mgr(sdk_path=sdk)
+        with patch("moment_to_action.qairt._manager.shutil.rmtree") as mock_rmtree:
+            mgr.clean()
+        mock_rmtree.assert_called_once_with(sdk, ignore_errors=True)
+
+    def test_clean_returns_removed_path(self, tmp_path: Path) -> None:
+        """Clean returns the path that was removed."""
+        sdk = tmp_path / "2.45.0.24"
+        sdk.mkdir()
+        mgr = _make_mgr(sdk_path=sdk)
+        with patch("moment_to_action.qairt._manager.shutil.rmtree"):
+            removed = mgr.clean()
+        assert removed == sdk
+
+    def test_clean_clears_internal_path(self, tmp_path: Path) -> None:
+        """Clean sets the internal sdk_path to None."""
+        sdk = tmp_path / "2.45.0.24"
+        sdk.mkdir()
+        mgr = _make_mgr(sdk_path=sdk)
+        with patch("moment_to_action.qairt._manager.shutil.rmtree"):
+            mgr.clean()
+        assert mgr.path is None

--- a/tests/unit/qairt/test_manager.py
+++ b/tests/unit/qairt/test_manager.py
@@ -214,6 +214,14 @@ class TestQairtSDKManagerInstall:
 
         assert mock_run.call_args.kwargs.get("capture_output") is False
 
+    def test_install_raises_when_already_installed(self, tmp_path: Path) -> None:
+        """Install raises RuntimeError when SDK is already available."""
+        sdk = tmp_path / "2.45.0.24"
+        sdk.mkdir(parents=True)
+        mgr = _make_mgr(sdk_path=sdk, install_dir=tmp_path)
+        with pytest.raises(RuntimeError, match="already installed"):
+            mgr.install(stream=False)
+
 
 @pytest.mark.unit
 class TestQairtSDKManagerVerify:

--- a/tests/unit/qairt/test_manager.py
+++ b/tests/unit/qairt/test_manager.py
@@ -224,6 +224,36 @@ class TestQairtSDKManagerInstall:
 
 
 @pytest.mark.unit
+class TestQairtSDKManagerFindSdkPath:
+    """Tests for QairtSDKManager._find_sdk_path."""
+
+    def test_find_sdk_path_returns_none_when_qairt_dir_missing(self, tmp_path: Path) -> None:
+        """_find_sdk_path returns None when qairt directory does not exist."""
+        mgr = _make_mgr(install_dir=tmp_path)
+        path = mgr._find_sdk_path()
+        assert path is None
+
+    def test_find_sdk_path_returns_none_when_no_version_match(self, tmp_path: Path) -> None:
+        """_find_sdk_path returns None when no versions match the pattern."""
+        base = tmp_path / "qairt"
+        base.mkdir()
+        (base / "2.44.0.24").mkdir()
+        mgr = _make_mgr(sdk_version="2.45.0", install_dir=tmp_path)
+        path = mgr._find_sdk_path()
+        assert path is None
+
+    def test_find_sdk_path_returns_first_match(self, tmp_path: Path) -> None:
+        """_find_sdk_path returns the first matching version directory."""
+        base = tmp_path / "qairt"
+        base.mkdir()
+        (base / "2.45.0.20").mkdir()
+        (base / "2.45.0.24").mkdir()
+        mgr = _make_mgr(sdk_version="2.45.0", install_dir=tmp_path)
+        path = mgr._find_sdk_path()
+        assert path == base / "2.45.0.20"
+
+
+@pytest.mark.unit
 class TestQairtSDKManagerVerify:
     """Tests for QairtSDKManager.verify."""
 

--- a/tests/unit/qairt/test_manager.py
+++ b/tests/unit/qairt/test_manager.py
@@ -224,6 +224,35 @@ class TestQairtSDKManagerInstall:
 
 
 @pytest.mark.unit
+class TestQairtSDKManagerCleanupZips:
+    """Tests for QairtSDKManager._cleanup_zip_files."""
+
+    def test_cleanup_removes_zip_files(self, tmp_path: Path) -> None:
+        """_cleanup_zip_files removes .zip files from install directory."""
+        (tmp_path / "2.45.0.260326.zip").touch()
+        (tmp_path / "other.zip").touch()
+        mgr = _make_mgr(install_dir=tmp_path)
+        mgr._cleanup_zip_files()
+        assert not (tmp_path / "2.45.0.260326.zip").exists()
+        assert not (tmp_path / "other.zip").exists()
+
+    def test_cleanup_ignores_non_zip_files(self, tmp_path: Path) -> None:
+        """_cleanup_zip_files only removes .zip files."""
+        (tmp_path / "file.txt").touch()
+        (tmp_path / "archive.tar.gz").touch()
+        mgr = _make_mgr(install_dir=tmp_path)
+        mgr._cleanup_zip_files()
+        assert (tmp_path / "file.txt").exists()
+        assert (tmp_path / "archive.tar.gz").exists()
+
+    def test_cleanup_handles_missing_files(self, tmp_path: Path) -> None:
+        """_cleanup_zip_files handles missing files gracefully."""
+        mgr = _make_mgr(install_dir=tmp_path)
+        mgr._cleanup_zip_files()
+        assert True
+
+
+@pytest.mark.unit
 class TestQairtSDKManagerFindSdkPath:
     """Tests for QairtSDKManager._find_sdk_path."""
 

--- a/tests/unit/test_cli_config.py
+++ b/tests/unit/test_cli_config.py
@@ -86,3 +86,32 @@ class TestConfigCommand:
         """Passing an invalid log level returns a non-zero exit code."""
         result = self._invoke(runner, ["log_level", "TRACE"])
         assert result.exit_code != 0
+
+    def test_qairt_sdk_version_in_table(self, runner: CliRunner) -> None:
+        """Config table includes qairt_sdk_version."""
+        result = self._invoke(runner, [])
+        assert result.exit_code == 0
+        assert "qairt_sdk_version" in result.output
+
+    def test_qairt_sdk_version_get(self, runner: CliRunner) -> None:
+        """Getting qairt_sdk_version returns the default."""
+        result = self._invoke(runner, ["qairt_sdk_version"])
+        assert result.exit_code == 0
+        assert "2.45.0" in result.output
+
+    def test_qairt_sdk_version_set(self, runner: CliRunner) -> None:
+        """Setting qairt_sdk_version persists the new value."""
+        self._invoke(runner, ["qairt_sdk_version", "2.44.0"])
+        result = self._invoke(runner, ["qairt_sdk_version"])
+        assert result.exit_code == 0
+        assert "2.44.0" in result.output
+
+    def test_qairt_sdk_path_in_json(self, runner: CliRunner) -> None:
+        """JSON output includes qairt_sdk_path key."""
+        result = self._invoke(runner, ["--json"])
+        assert result.exit_code == 0
+        import json
+
+        data = json.loads(result.output)
+        assert "qairt_sdk_path" in data
+        assert data["qairt_sdk_path"] is None

--- a/tests/unit/utils/test_schemas.py
+++ b/tests/unit/utils/test_schemas.py
@@ -1,0 +1,49 @@
+"""Unit tests for utils.schemas."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel
+
+from moment_to_action.utils.schemas import update_frozen
+
+
+class _Model(BaseModel, frozen=True):
+    x: int = 0
+    y: str = "hello"
+
+
+@pytest.mark.unit
+class TestUpdateFrozen:
+    """Tests for update_frozen."""
+
+    def test_returns_updated_field(self) -> None:
+        """Updated field has the new value."""
+        m = _Model(x=1, y="a")
+        result = update_frozen(m, x=99)
+        assert result.x == 99
+
+    def test_unmentioned_fields_preserved(self) -> None:
+        """Fields not in updates keep their original values."""
+        m = _Model(x=1, y="a")
+        result = update_frozen(m, x=2)
+        assert result.y == "a"
+
+    def test_returns_same_type(self) -> None:
+        """Return type matches the input model type."""
+        m = _Model()
+        result = update_frozen(m, y="new")
+        assert type(result) is _Model
+
+    def test_original_unchanged(self) -> None:
+        """Original frozen model is not mutated."""
+        m = _Model(x=5)
+        update_frozen(m, x=10)
+        assert m.x == 5
+
+    def test_multiple_fields_updated(self) -> None:
+        """Multiple fields can be updated in one call."""
+        m = _Model(x=1, y="old")
+        result = update_frozen(m, x=2, y="new")
+        assert result.x == 2
+        assert result.y == "new"


### PR DESCRIPTION
## Changes
- Add `m2a qairt` CLI subcommand group with install, verify, clean, info subcommands
- Implement QairtManager for QAIRT SDK version/dependency management
- Extend AppConfig to persist QAIRT SDK settings

## Technical Details
QairtManager manages dependencies and validates installations. AppConfig stores active version and install directory. CLI commands wrap manager capabilities with user-friendly output.

## Verification
- [x] Unit tests
- [x] Integration tests
- [x] Manual testing (all commands execute and output correctly)
  - [x] qairt install/verify/clean/info commands

## Related Issues
Closes #93 