### PR TITLE
Remove unnecessary local imports and ImportError guards

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,9 +109,6 @@ ignore = [
     # Formatter-incompatible
     "COM812",
 
-    # Lazy/conditional imports are intentional for optional deps (cv2, tf, onnxruntime)
-    "PLC0415",
-
     # Any is appropriate for opaque runtime handles (TFLite interpreters, ONNX sessions)
     "ANN401",
 

--- a/src/moment_to_action/hardware/_platforms/_runtimes/_torch_policy.py
+++ b/src/moment_to_action/hardware/_platforms/_runtimes/_torch_policy.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import torch
+
 from moment_to_action.hardware._types import TorchExecutionPolicy
 
 
@@ -14,8 +16,6 @@ def resolve_torch_execution_policy(requested: str = "auto") -> TorchExecutionPol
     Returns:
         A resolved :class:`TorchExecutionPolicy`.
     """
-    import torch
-
     if requested != "auto":
         device = torch.device(requested)
     elif torch.cuda.is_available():

--- a/src/moment_to_action/hardware/_platforms/x86_64/_resources.py
+++ b/src/moment_to_action/hardware/_platforms/x86_64/_resources.py
@@ -18,6 +18,7 @@ based on CPU frequency and utilization.
 from __future__ import annotations
 
 import logging
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import ClassVar
@@ -94,8 +95,6 @@ class X86_64ResourceMonitor(ResourceMonitor):  # noqa: N801
         Returns:
             A ComputeUnitUsageSample with RAPL-based power reading.
         """
-        import time  # only needed for RAPL delta timing
-
         try:
             energy_uj = int(_RAPL_ENERGY_PATH.read_text().strip())
             now = time.time()

--- a/src/moment_to_action/stages/video/_preprocess.py
+++ b/src/moment_to_action/stages/video/_preprocess.py
@@ -22,6 +22,7 @@ import logging
 from typing import TYPE_CHECKING
 
 import attrs
+import cv2
 import numpy as np
 
 from moment_to_action.hardware import ComputeUnit
@@ -163,12 +164,7 @@ class ImagePreprocessor(BasePreprocessor[RawFrameMessage, ProcessedFrame]):
         """Convert BGR (OpenCV default) to RGB."""
         if image.frame is None:
             return image
-        try:
-            import cv2
-
-            rgb = cv2.cvtColor(image.frame, cv2.COLOR_BGR2RGB)
-        except ImportError:
-            rgb = image.frame[..., ::-1].copy()
+        rgb = cv2.cvtColor(image.frame, cv2.COLOR_BGR2RGB)
         return RawFrameMessage(
             frame=rgb, timestamp=image.timestamp, width=image.width, height=image.height
         )
@@ -206,15 +202,10 @@ class ImagePreprocessor(BasePreprocessor[RawFrameMessage, ProcessedFrame]):
         if image.frame is None:
             msg = "Cannot resize a RawFrameMessage with frame=None"
             raise ValueError(msg)
-        try:
-            import cv2
-
-            if letterbox:
-                frame = self._letterbox_cv2(image.frame, target_size)
-            else:
-                frame = cv2.resize(image.frame, (target_size[1], target_size[0]))
-        except ImportError:
-            frame = self._resize_numpy(image.frame, target_size)
+        if letterbox:
+            frame = self._letterbox_cv2(image.frame, target_size)
+        else:
+            frame = cv2.resize(image.frame, (target_size[1], target_size[0]))
 
         # Use a dedicated resize buffer (not the final output buffer which may be crop_size)
         resize_buf = self._buffers.get_or_register(
@@ -247,8 +238,6 @@ class ImagePreprocessor(BasePreprocessor[RawFrameMessage, ProcessedFrame]):
 
     def _letterbox_cv2(self, image: np.ndarray, target_size: tuple) -> np.ndarray:
         """Resize preserving aspect ratio, pad remainder. Used by YOLO."""
-        import cv2
-
         h, w = image.shape[:2]
         th, tw = target_size
         scale = min(tw / w, th / h)
@@ -259,14 +248,6 @@ class ImagePreprocessor(BasePreprocessor[RawFrameMessage, ProcessedFrame]):
         pad_left = (tw - new_w) // 2
         padded[pad_top : pad_top + new_h, pad_left : pad_left + new_w] = resized
         return padded
-
-    def _resize_numpy(self, image: np.ndarray, target_size: tuple) -> np.ndarray:
-        """Numpy-only nearest-neighbor fallback."""
-        th, tw = target_size
-        h, w = image.shape[:2]
-        row_idx = (np.arange(th) * h / th).astype(int)
-        col_idx = (np.arange(tw) * w / tw).astype(int)
-        return image[row_idx][:, col_idx]
 
     def reconfigure(self, config: ImagePreprocessConfig) -> None:
         """Swap config and re-allocate buffers if sizes changed."""

--- a/tests/unit/stages/video/test_preprocess.py
+++ b/tests/unit/stages/video/test_preprocess.py
@@ -6,9 +6,7 @@ PreprocessorStage (end-to-end pipeline).
 
 from __future__ import annotations
 
-import sys
 import time
-from unittest import mock
 
 import numpy as np
 import pytest
@@ -381,8 +379,6 @@ class TestPreprocessorStageE2E:
 
     def test_preprocessor_stage_invalid_input_type(self) -> None:
         """Test PreprocessorStage rejects non-RawFrameMessage."""
-        from moment_to_action.messages.video import FrameTensorMessage
-
         rng = np.random.default_rng()
 
         tensor = rng.standard_normal((1, 3, 256, 256)).astype(np.float32)
@@ -580,24 +576,6 @@ class TestToRGBEdgeCases:
         assert result.width == msg.width
         assert result.height == msg.height
 
-    def test_to_rgb_cv2_import_error_numpy_fallback(self) -> None:
-        """Test _to_rgb uses numpy fallback when cv2 import fails."""
-        img_array = np.array([[[1, 2, 3], [4, 5, 6]]], dtype=np.uint8)
-        msg = RawFrameMessage(
-            frame=img_array,
-            timestamp=time.time(),
-            width=2,
-            height=1,
-        )
-        preprocessor = ImagePreprocessor()
-
-        with mock.patch.dict(sys.modules, {"cv2": None}):
-            result = preprocessor._to_rgb(msg)
-
-        assert result.frame is not None
-        assert result.frame.shape == img_array.shape
-        np.testing.assert_array_equal(result.frame, img_array[..., ::-1])
-
     def test_to_rgb_normal_operation(self) -> None:
         """Test _to_rgb correctly converts BGR to RGB."""
         img_array = np.array([[[1, 2, 3], [4, 5, 6]]], dtype=np.uint8)
@@ -629,78 +607,6 @@ class TestResizeEdgeCases:
         preprocessor = ImagePreprocessor()
         with pytest.raises(ValueError, match="Cannot resize a RawFrameMessage with frame=None"):
             preprocessor._resize(msg, (256, 256), letterbox=False)
-
-    def test_resize_cv2_import_error_calls_numpy_fallback(self) -> None:
-        """Test _resize falls back to _resize_numpy when cv2 import fails."""
-        img_array = np.full((480, 640, 3), 128, dtype=np.uint8)
-        msg = RawFrameMessage(
-            frame=img_array,
-            timestamp=time.time(),
-            width=640,
-            height=480,
-        )
-        preprocessor = ImagePreprocessor()
-
-        with mock.patch.dict(sys.modules, {"cv2": None}):
-            result = preprocessor._resize(msg, (256, 256), letterbox=False)
-
-        assert isinstance(result, ProcessedFrame)
-        assert result.data.shape == (256, 256, 3)
-        assert result.data.dtype == np.float32
-
-
-@pytest.mark.unit
-class TestResizeNumpy:
-    """Test _resize_numpy directly."""
-
-    def test_resize_numpy_small_array(self) -> None:
-        """Test _resize_numpy with a small synthetic array."""
-        img_array = np.array(
-            [
-                [[1, 1, 1], [2, 2, 2]],
-                [[3, 3, 3], [4, 4, 4]],
-            ],
-            dtype=np.uint8,
-        )
-        preprocessor = ImagePreprocessor()
-        result = preprocessor._resize_numpy(img_array, (4, 4))
-
-        assert result.shape == (4, 4, 3)
-        assert result.dtype == np.uint8
-
-    def test_resize_numpy_nearest_neighbor(self) -> None:
-        """Test _resize_numpy uses nearest-neighbor resampling."""
-        img_array = np.array(
-            [[[100, 100, 100], [200, 200, 200]]],
-            dtype=np.uint8,
-        )
-        preprocessor = ImagePreprocessor()
-        result = preprocessor._resize_numpy(img_array, (2, 4))
-
-        assert result.shape == (2, 4, 3)
-        assert np.all(result[0, 0] == [100, 100, 100])
-        assert np.all(result[0, -1] == [200, 200, 200])
-
-    def test_resize_numpy_scaling_up(self) -> None:
-        """Test _resize_numpy scaling up."""
-        img_array = np.array(
-            [[[50, 50, 50], [100, 100, 100]]],
-            dtype=np.uint8,
-        )
-        preprocessor = ImagePreprocessor()
-        result = preprocessor._resize_numpy(img_array, (3, 6))
-
-        assert result.shape == (3, 6, 3)
-        assert result.dtype == np.uint8
-
-    def test_resize_numpy_scaling_down(self) -> None:
-        """Test _resize_numpy scaling down."""
-        img_array = np.full((100, 100, 3), 128, dtype=np.uint8)
-        preprocessor = ImagePreprocessor()
-        result = preprocessor._resize_numpy(img_array, (10, 10))
-
-        assert result.shape == (10, 10, 3)
-        assert result.dtype == np.uint8
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Changes
- Moved `import torch` from inside `resolve_torch_execution_policy()` to module top-level
- Moved `import time` from inside `_read_rapl()` to module top-level  
- Removed cv2 `try/except ImportError` guards in `_preprocess.py` (3 methods)
- Deleted `_resize_numpy()` method (numpy fallback for cv2, now dead code)
- Removed 5 test methods covering deleted fallback paths
- Removed `PLC0415` from ruff ignore list

## Technical Details
cv2, torch, and time are hard dependencies in `pyproject.toml`. The try/except ImportError guards and local imports were unnecessary and represented dead code paths. One legitimate guard remains: `ai_edge_litert` in `_litert.py` (2 files) — the wheel may not install on all platforms even though listed as a dep, and the tensorflow fallback provides identical interface.

## Verification
- [x] Unit tests (80 video stage tests pass, torch policy and resources tests pass)
- [x] Lint (ruff, mypy, format all clean)
- [x] 100% coverage maintained on all touched files

## Related Issues
Closes #54