### PR TITLE
Fix PLC0415 lint errors from ruff update

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,8 @@ ignore = [
     "S108",
     # undocumented public packages (D104)
     "D104",
+    # local imports inside test methods are intentional (isolation, deferred heavy deps)
+    "PLC0415",
 ]
 
 [tool.ruff.lint.pydocstyle]

--- a/scripts/draw_detections.py
+++ b/scripts/draw_detections.py
@@ -10,6 +10,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import colorsys
 import logging
 import sys
 from typing import TYPE_CHECKING
@@ -102,8 +103,6 @@ det: DetectionMessage = capture.detections
 def label_color(label: str) -> tuple[int, int, int]:
     """Return a deterministic BGR color for a label."""
     h = abs(hash(label)) % 179
-    import colorsys
-
     r, g, b = colorsys.hsv_to_rgb(h / 179.0, 0.85, 0.95)
     return (int(b * 255), int(g * 255), int(r * 255))  # BGR
 

--- a/src/moment_to_action/qairt/_manager.py
+++ b/src/moment_to_action/qairt/_manager.py
@@ -10,6 +10,8 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from moment_to_action.qairt._deps import check_system_deps as _check_system_deps
+
 if TYPE_CHECKING:
     from moment_to_action.config import AppConfig
     from moment_to_action.paths import PathManager
@@ -99,9 +101,7 @@ class QairtSDKManager:
 
     def check_system_deps(self) -> list[str]:
         """Return list of missing system package names for the current distro."""
-        from moment_to_action.qairt._deps import check_system_deps
-
-        missing = check_system_deps()
+        missing = _check_system_deps()
         if missing:
             _log.warning(f"Missing system dependencies: {', '.join(missing)}")
         else:


### PR DESCRIPTION
## Changes
- Add `PLC0415` to `tests/**/*.py` per-file-ignores (local imports in tests are intentional)
- Move `import colorsys` to top-level in `scripts/draw_detections.py`
- Move `_deps` import to top-level in `qairt/_manager.py`, aliased as `_check_system_deps` to avoid name clash with method

## Technical Details
`select = ["ALL"]` picked up `PLC0415` from a ruff update, causing 93 errors. Test local imports are a deliberate pattern (isolation, deferred heavy deps). The two src violations are straightforward moves to top-level.

## Verification
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing (describe below)
  - [x] `just lint` passes clean

## Related Issues