### PR TITLE
Add image processing stage infrastructure

### DIFF
--- a/scripts/draw_detections.py
+++ b/scripts/draw_detections.py
@@ -1,20 +1,23 @@
-"""Runs the YOLO pipeline and draws bounding boxes on the image.
+"""Runs YOLO detection on an image and saves an annotated copy with bounding boxes.
 
 Usage:
-    uv run python scripts/draw_detections.py --image weapon.jpg
-    uv run python scripts/draw_detections.py --image weapon.jpg --conf 0.3 --out result.jpg
+    uv run python scripts/draw_detections.py --image pedestrian.jpg
+    uv run python scripts/draw_detections.py --image pedestrian.jpg --out result.jpg
+    uv run python scripts/draw_detections.py --image pedestrian.jpg --conf 0.4 --device npu
 """
 
 from __future__ import annotations
 
 import argparse
 import logging
+from pathlib import Path
 
+import cv2
 from rich.console import Console
 from rich.logging import RichHandler
 
 from moment_to_action.hardware import ComputeBackend, ComputeUnit
-from moment_to_action.models import ModelID, ModelManager
+from moment_to_action.models import ModelID, ModelManager, YOLOModel
 from moment_to_action.paths import PathManager
 
 logging.basicConfig(
@@ -29,17 +32,49 @@ logger = logging.getLogger(__name__)
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--image", required=True)
-parser.add_argument("--conf", type=float, default=0.3)
-parser.add_argument("--out", default="detections.jpg")
+parser.add_argument("--out", default=None, help="Output path (default: annotated_<input>)")
+parser.add_argument("--device", choices=["cpu", "npu"], default="cpu")
+parser.add_argument("--conf", type=float, default=0.3, help="Confidence threshold")
 args = parser.parse_args()
 
-device = ComputeUnit.CPU
+frame = cv2.imread(args.image)
+if frame is None:
+    logger.error("Could not load image: %s", args.image)
+    raise SystemExit(1)
+
+device = ComputeUnit.NPU if args.device == "npu" else ComputeUnit.CPU
 compute_backend = ComputeBackend(preferred_unit=device)
 manager = ModelManager(PathManager())
 
 # ── load model ─────────────────────────────────────────────────────────────
-model = manager.get_model(ModelID.YOLO_V8)
+model = manager.get_model(ModelID.YOLO_V8, confidence_threshold=args.conf)
+if not isinstance(model, YOLOModel):
+    err_msg = f"Expected YOLOModel, got {type(model).__name__}"
+    raise TypeError(err_msg)
 model.load(compute_backend)
 
-logger.info("Model loaded. Drawing pipeline wiring (ImageDetectionStage) is deferred to PR 2.")
+# ── run inference ──────────────────────────────────────────────────────────
+prepared = model.prepare(frame)
+raw = model.run(prepared)
+detections = model.decode(raw, original_size=(frame.shape[0], frame.shape[1]))
+
+# ── draw bounding boxes ────────────────────────────────────────────────────
+annotated = frame.copy()
+for det in detections:
+    x1 = int(det.bbox.x1)
+    y1 = int(det.bbox.y1)
+    x2 = int(det.bbox.x2)
+    y2 = int(det.bbox.y2)
+    cv2.rectangle(annotated, (x1, y1), (x2, y2), (0, 255, 0), 2)
+    label = f"{det.label} {det.confidence:.2f}"
+    cv2.putText(annotated, label, (x1, y1 - 8), cv2.FONT_HERSHEY_SIMPLEX, 0.55, (0, 255, 0), 1)
+
+# ── save result ────────────────────────────────────────────────────────────
+output_path = args.out or f"annotated_{Path(args.image).name}"
+if not cv2.imwrite(output_path, annotated):
+    logger.error("Failed to write output image: %s", output_path)
+    raise SystemExit(1)
+
+logger.info("Found %d detection(s). Saved annotated image → %s", len(detections), output_path)
+
 model.unload()

--- a/scripts/run_yolo_pipeline.py
+++ b/scripts/run_yolo_pipeline.py
@@ -1,23 +1,30 @@
-"""Runs the YOLO → LLM baseline pipeline on an image.
+"""Runs the YOLO object-detection pipeline on a single image.
 
 Moved from ``src/moment_to_action/edgeperceive/pipeline/run_yolo_pipeline.py``.
 
 Usage:
     uv run python scripts/run_yolo_pipeline.py --image weapon.jpg
-    uv run python scripts/run_yolo_pipeline.py --image weapon.jpg --device npu
+    uv run python scripts/run_yolo_pipeline.py --image weapon.jpg --device npu --conf 0.4
 """
 
 from __future__ import annotations
 
 import argparse
 import logging
+import time
 
+import cv2
 from rich.console import Console
 from rich.logging import RichHandler
 
 from moment_to_action.hardware import ComputeBackend, ComputeUnit
+from moment_to_action.messages import DetectionMessage
+from moment_to_action.messages.sensor import RawFrameMessage
 from moment_to_action.models import ModelID, ModelManager
+from moment_to_action.models.image.detection._base import ImageDetectionModel
 from moment_to_action.paths import PathManager
+from moment_to_action.stages import Pipeline
+from moment_to_action.stages.image import ImageDetectionStage
 
 logging.basicConfig(
     level=logging.INFO,
@@ -35,13 +42,40 @@ parser.add_argument("--device", choices=["cpu", "npu"], default="cpu")
 parser.add_argument("--conf", type=float, default=0.5, help="Confidence threshold")
 args = parser.parse_args()
 
+frame = cv2.imread(args.image)
+if frame is None:
+    logger.error("Could not load image: %s", args.image)
+    raise SystemExit(1)
+
 device = ComputeUnit.NPU if args.device == "npu" else ComputeUnit.CPU
 compute_backend = ComputeBackend(preferred_unit=device)
 manager = ModelManager(PathManager())
 
 # ── load model ─────────────────────────────────────────────────────────────
-model = manager.get_model(ModelID.YOLO_V8)
+model = manager.get_model(ModelID.YOLO_V8, confidence_threshold=args.conf)
+if not isinstance(model, ImageDetectionModel):
+    err_msg = f"Expected ImageDetectionModel, got {type(model).__name__}"
+    raise TypeError(err_msg)
 model.load(compute_backend)
 
-logger.info("Model loaded. Pipeline wiring (ImageDetectionStage) is deferred to PR 2.")
+# ── build and run pipeline ─────────────────────────────────────────────────
+stage = ImageDetectionStage(model=model)
+pipeline = Pipeline(stages=[stage])
+
+raw_msg = RawFrameMessage(
+    frame=frame,
+    timestamp=time.time(),
+    width=frame.shape[1],
+    height=frame.shape[0],
+)
+result = pipeline.run(raw_msg)
+
+# ── display results ────────────────────────────────────────────────────────
+if isinstance(result, DetectionMessage):
+    logger.info("Found %d detection(s):", len(result.detections))
+    for det in result.detections:
+        logger.info("  %s  conf=%.2f  bbox=%s", det.label, det.confidence, det.bbox)
+else:
+    logger.warning("Pipeline returned no detection result.")
+
 model.unload()

--- a/src/moment_to_action/metrics/_types.py
+++ b/src/moment_to_action/metrics/_types.py
@@ -44,11 +44,14 @@ class SpanType(Enum):
     STAGE = auto()
     """Individual stage execution span (e.g. trigger, vision, LLM)."""
 
-    PREPROCESS = auto()
+    MODEL_PREPROCESS = auto()
     """Time taken for preprocessing steps before a model inference (e.g. resampling audio)."""
 
     MODEL_INFERENCE = auto()
     """Time taken for a model inference (e.g. vision, LLM)."""
+
+    MODEL_POST_PROCESS = auto()
+    """Time taken for post-processing steps after a model inference (e.g. NMS, decoding)."""
 
 
 @attrs.frozen

--- a/src/moment_to_action/models/_manager.py
+++ b/src/moment_to_action/models/_manager.py
@@ -180,6 +180,7 @@ class ModelManager:
         model_id: ModelID,
         *,
         variant: str = DEFAULT_KEY,
+        **model_kwargs: object,
     ) -> BaseModel:
         """Construct an unloaded model instance for the given model and variant.
 
@@ -190,6 +191,9 @@ class ModelManager:
         Args:
             model_id: Identifier of the desired model.
             variant: Variant name to load.  Defaults to :data:`DEFAULT_KEY`.
+            **model_kwargs: Additional keyword arguments forwarded verbatim to
+                the model constructor.  Use for model-specific parameters such
+                as ``confidence_threshold`` on detection models.
 
         Returns:
             An unloaded :class:`~moment_to_action.models._base.BaseModel` subclass instance.
@@ -197,7 +201,7 @@ class ModelManager:
         info = self._get_model_info(model_id)
         source = self._get_source(info, variant)
         path = self.get_path(model_id, variant)
-        return info.model_class(variant, path, source.format)  # type: ignore[call-arg]
+        return info.model_class(variant, path, source.format, **model_kwargs)  # type: ignore[call-arg]
 
     def clear_cache(self) -> ModelCacheContents:
         """Clear all downloaded model files from the cache.

--- a/src/moment_to_action/stages/__init__.py
+++ b/src/moment_to_action/stages/__init__.py
@@ -2,7 +2,8 @@
 
 Consumers import from the submodules directly::
 
-    from moment_to_action.stages.video import YOLOStage, PreprocessorStage, ClipBufferStage
+    from moment_to_action.stages.image import ImageStage, ImageDetectionStage
+    from moment_to_action.stages.video import PreprocessorStage, ClipBufferStage
     from moment_to_action.stages.vlm import MobileCLIPStage, SmolVLM2Stage
     from moment_to_action.stages.llm import ReasoningStage
 """
@@ -11,7 +12,7 @@ from __future__ import annotations
 
 from moment_to_action.pipeline import Pipeline
 
-from . import llm, video, vlm
+from . import image, llm, video, vlm
 from ._base import Stage
 
-__all__ = ["Pipeline", "Stage", "llm", "video", "vlm"]
+__all__ = ["Pipeline", "Stage", "image", "llm", "video", "vlm"]

--- a/src/moment_to_action/stages/_preprocess.py
+++ b/src/moment_to_action/stages/_preprocess.py
@@ -126,7 +126,7 @@ class BasePreprocessor(ABC, Generic[InputT, OutputT]):
         self._validate(data)
 
         # Time the processing and report to metrics
-        with metrics.start_span(SpanType.PREPROCESS, self.__class__.__name__) as span:
+        with metrics.start_span(SpanType.MODEL_PREPROCESS, self.__class__.__name__) as span:
             span_id = span.id_  # save so we can report after processing
 
             # Run the actual preprocessing logic implemented by the subclass

--- a/src/moment_to_action/stages/image/__init__.py
+++ b/src/moment_to_action/stages/image/__init__.py
@@ -1,0 +1,8 @@
+"""Image stages package."""
+
+from __future__ import annotations
+
+from ._base import ImageStage
+from ._detection import ImageDetectionStage
+
+__all__ = ["ImageDetectionStage", "ImageStage"]

--- a/src/moment_to_action/stages/image/_base.py
+++ b/src/moment_to_action/stages/image/_base.py
@@ -1,0 +1,14 @@
+"""Marker base class for image-input pipeline stages."""
+
+from __future__ import annotations
+
+from moment_to_action.stages._base import Stage
+
+
+class ImageStage(Stage):
+    """Marker base class for stages that process image-based messages.
+
+    Extends :class:`~moment_to_action.stages._base.Stage` without adding new
+    abstract methods.  Subclasses must implement
+    :meth:`~moment_to_action.stages._base.Stage._process`.
+    """

--- a/src/moment_to_action/stages/image/_detection.py
+++ b/src/moment_to_action/stages/image/_detection.py
@@ -1,0 +1,78 @@
+"""ImageDetectionStage — wraps an ImageDetectionModel in a pipeline stage."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from moment_to_action.messages.detection import DetectionMessage
+from moment_to_action.messages.sensor import RawFrameMessage
+from moment_to_action.metrics import SpanType
+from moment_to_action.stages.image._base import ImageStage
+
+if TYPE_CHECKING:
+    from moment_to_action.messages import Message
+    from moment_to_action.metrics import MetricsCollector
+    from moment_to_action.models.image.detection._base import ImageDetectionModel
+
+logger = logging.getLogger(__name__)
+
+
+class ImageDetectionStage(ImageStage):
+    """Pipeline stage that runs object detection on a raw frame.
+
+    Wraps any :class:`~moment_to_action.models.image.detection._base.ImageDetectionModel`
+    in the standard :class:`~moment_to_action.stages._base.Stage` interface.  Accepts a
+    :class:`~moment_to_action.messages.sensor.RawFrameMessage` and returns a
+    :class:`~moment_to_action.messages.detection.DetectionMessage`.
+
+    Short-circuits (returns ``None``) for any other message type or when the
+    incoming frame is ``None`` (dropped frame).
+    """
+
+    def __init__(self, model: ImageDetectionModel) -> None:
+        """Initialize the stage with a detection model.
+
+        Args:
+            model: An :class:`~moment_to_action.models.image.detection._base.ImageDetectionModel`
+                instance.  The caller must call ``model.load(backend)`` before passing
+                it here.
+        """
+        self._model = model
+
+    def _process(self, msg: Message, metrics: MetricsCollector) -> Message | None:
+        """Run detection on a raw frame, timing each model call with the metrics collector.
+
+        Args:
+            msg: Incoming pipeline message.  Must be a
+                :class:`~moment_to_action.messages.sensor.RawFrameMessage` with a
+                non-``None`` ``frame`` field.
+            metrics: Metrics collector used to record per-call timing spans for
+                ``prepare``, ``run``, and ``post_proc``.
+
+        Returns:
+            A :class:`~moment_to_action.messages.detection.DetectionMessage` with
+            detection results, or ``None`` if ``msg`` is not a
+            :class:`~moment_to_action.messages.sensor.RawFrameMessage` or if
+            ``msg.frame`` is ``None``.
+        """
+        if not isinstance(msg, RawFrameMessage):
+            logger.warning(
+                "%s: expected RawFrameMessage, got %s — skipping",
+                self.name,
+                type(msg).__name__,
+            )
+            return None
+        if msg.frame is None:
+            return None
+
+        with metrics.start_span(SpanType.MODEL_PREPROCESS, "prepare"):
+            prepared = self._model.prepare(msg.frame)
+
+        with metrics.start_span(SpanType.MODEL_INFERENCE, "run"):
+            raw = self._model.run(prepared)
+
+        with metrics.start_span(SpanType.MODEL_POST_PROCESS, "post_process"):
+            detections = self._model.post_proc(raw)
+
+        return DetectionMessage(timestamp=msg.timestamp, detections=detections)

--- a/tests/unit/metrics/test_collector.py
+++ b/tests/unit/metrics/test_collector.py
@@ -191,7 +191,7 @@ class TestStartSpan:
         with collector.start_trace():
             with collector.start_span(SpanType.STAGE, "span1"):
                 pass
-            with collector.start_span(SpanType.PREPROCESS, "span2"):
+            with collector.start_span(SpanType.MODEL_PREPROCESS, "span2"):
                 pass
 
         assert len(collector.spans) == 2
@@ -271,7 +271,7 @@ class TestSpanNesting:
         """Test single level of nested spans (parent → child)."""
         with collector.start_trace():
             with collector.start_span(SpanType.STAGE, "parent") as parent_span:
-                with collector.start_span(SpanType.PREPROCESS, "child") as child_span:
+                with collector.start_span(SpanType.MODEL_PREPROCESS, "child") as child_span:
                     assert child_span.parent_id == parent_span.id_
 
         assert len(collector.spans) == 2
@@ -280,7 +280,7 @@ class TestSpanNesting:
         """Test multiple levels of span nesting (parent → child → grandchild)."""
         with collector.start_trace():
             with collector.start_span(SpanType.STAGE, "parent") as parent:
-                with collector.start_span(SpanType.PREPROCESS, "child") as child:
+                with collector.start_span(SpanType.MODEL_PREPROCESS, "child") as child:
                     with collector.start_span(SpanType.MODEL_INFERENCE, "grandchild") as grandchild:
                         assert child.parent_id == parent.id_
                         assert grandchild.parent_id == child.id_
@@ -292,9 +292,9 @@ class TestSpanNesting:
         with collector.start_trace():
             with collector.start_span(SpanType.STAGE, "parent") as parent:
                 parent_id = parent.id_
-                with collector.start_span(SpanType.PREPROCESS, "child1") as child1:
+                with collector.start_span(SpanType.MODEL_PREPROCESS, "child1") as child1:
                     assert child1.parent_id == parent_id
-                with collector.start_span(SpanType.PREPROCESS, "child2") as child2:
+                with collector.start_span(SpanType.MODEL_PREPROCESS, "child2") as child2:
                     assert child2.parent_id == parent_id
 
         # Verify both children have same parent_id
@@ -306,10 +306,10 @@ class TestSpanNesting:
         """Test that all nested spans are stored in collector.spans."""
         with collector.start_trace():
             with collector.start_span(SpanType.STAGE, "parent"):
-                with collector.start_span(SpanType.PREPROCESS, "child1"):
+                with collector.start_span(SpanType.MODEL_PREPROCESS, "child1"):
                     with collector.start_span(SpanType.MODEL_INFERENCE, "grandchild1"):
                         pass
-                with collector.start_span(SpanType.PREPROCESS, "child2"):
+                with collector.start_span(SpanType.MODEL_PREPROCESS, "child2"):
                     pass
 
         assert len(collector.spans) == 4
@@ -320,7 +320,7 @@ class TestSpanNesting:
             with collector.start_span(SpanType.STAGE, "parent"):
                 # Parent should be current
                 assert collector.current_span.name == "parent"
-                with collector.start_span(SpanType.PREPROCESS, "child"):
+                with collector.start_span(SpanType.MODEL_PREPROCESS, "child"):
                     # Child should be current
                     assert collector.current_span.name == "child"
                 # Parent should be current again
@@ -330,7 +330,7 @@ class TestSpanNesting:
         """Test that spans must be ended in LIFO order (reverse of start order)."""
         with collector.start_trace():
             with collector.start_span(SpanType.STAGE, "parent"):
-                with collector.start_span(SpanType.PREPROCESS, "child"):
+                with collector.start_span(SpanType.MODEL_PREPROCESS, "child"):
                     pass
 
                 # Trying to manually mess with span stack would be caught
@@ -518,7 +518,7 @@ class TestNullMetricsCollector:
         with collector.start_trace():
             with collector.start_span(SpanType.STAGE, "span1"):
                 pass
-            with collector.start_span(SpanType.PREPROCESS, "span2"):
+            with collector.start_span(SpanType.MODEL_PREPROCESS, "span2"):
                 pass
 
         with collector.start_trace():
@@ -549,7 +549,7 @@ class TestErrorHandling:
             with collector.start_trace():
                 try:
                     with collector.start_span(SpanType.STAGE, "span1"):
-                        with collector.start_span(SpanType.PREPROCESS, "span2"):
+                        with collector.start_span(SpanType.MODEL_PREPROCESS, "span2"):
                             # Manually try to mess with the span stack
                             collector._span_stack.pop()  # Remove span2
                 except RuntimeError:  # noqa: TRY203
@@ -569,7 +569,7 @@ class TestErrorHandling:
         """Test that multiple nested spans are properly cleaned up."""
         with collector.start_trace():
             with collector.start_span(SpanType.STAGE, "s1"):
-                with collector.start_span(SpanType.PREPROCESS, "s2"):
+                with collector.start_span(SpanType.MODEL_PREPROCESS, "s2"):
                     with collector.start_span(SpanType.MODEL_INFERENCE, "s3"):
                         pass
 
@@ -594,11 +594,11 @@ class TestSpanTypes:
             with collector.start_span(SpanType.STAGE, "stage") as span:
                 assert span.type_ == SpanType.STAGE
 
-    def test_span_with_preprocess_type(self, collector: MetricsCollector) -> None:
-        """Test creating span with PREPROCESS type."""
+    def test_span_with_model_preprocess_type(self, collector: MetricsCollector) -> None:
+        """Test creating span with MODEL_PREPROCESS type."""
         with collector.start_trace():
-            with collector.start_span(SpanType.PREPROCESS, "preprocess") as span:
-                assert span.type_ == SpanType.PREPROCESS
+            with collector.start_span(SpanType.MODEL_PREPROCESS, "preprocess") as span:
+                assert span.type_ == SpanType.MODEL_PREPROCESS
 
     def test_span_with_model_inference_type(self, collector: MetricsCollector) -> None:
         """Test creating span with MODEL_INFERENCE type."""
@@ -606,13 +606,20 @@ class TestSpanTypes:
             with collector.start_span(SpanType.MODEL_INFERENCE, "inference") as span:
                 assert span.type_ == SpanType.MODEL_INFERENCE
 
+    def test_span_with_model_post_process_type(self, collector: MetricsCollector) -> None:
+        """Test creating span with MODEL_POST_PROCESS type."""
+        with collector.start_trace():
+            with collector.start_span(SpanType.MODEL_POST_PROCESS, "post_process") as span:
+                assert span.type_ == SpanType.MODEL_POST_PROCESS
+
     def test_all_span_types_work_in_trace(self, collector: MetricsCollector) -> None:
         """Test that all SpanType values work within a trace."""
         span_types = [
             SpanType.PIPELINE,
             SpanType.STAGE,
-            SpanType.PREPROCESS,
+            SpanType.MODEL_PREPROCESS,
             SpanType.MODEL_INFERENCE,
+            SpanType.MODEL_POST_PROCESS,
         ]
 
         with collector.start_trace():

--- a/tests/unit/metrics/test_types.py
+++ b/tests/unit/metrics/test_types.py
@@ -44,24 +44,30 @@ class TestSpanType:
         assert hasattr(SpanType, "STAGE")
         assert isinstance(SpanType.STAGE, SpanType)
 
-    def test_spantype_preprocess_member(self) -> None:
-        """Test SpanType.PREPROCESS member."""
-        assert hasattr(SpanType, "PREPROCESS")
-        assert isinstance(SpanType.PREPROCESS, SpanType)
+    def test_spantype_model_preprocess_member(self) -> None:
+        """Test SpanType.MODEL_PREPROCESS member."""
+        assert hasattr(SpanType, "MODEL_PREPROCESS")
+        assert isinstance(SpanType.MODEL_PREPROCESS, SpanType)
 
     def test_spantype_model_inference_member(self) -> None:
         """Test SpanType.MODEL_INFERENCE member."""
         assert hasattr(SpanType, "MODEL_INFERENCE")
         assert isinstance(SpanType.MODEL_INFERENCE, SpanType)
 
+    def test_spantype_model_post_process_member(self) -> None:
+        """Test SpanType.MODEL_POST_PROCESS member."""
+        assert hasattr(SpanType, "MODEL_POST_PROCESS")
+        assert isinstance(SpanType.MODEL_POST_PROCESS, SpanType)
+
     def test_spantype_all_members(self) -> None:
         """Test that all expected SpanType members exist."""
         members = [member.name for member in SpanType]
         assert "PIPELINE" in members
         assert "STAGE" in members
-        assert "PREPROCESS" in members
+        assert "MODEL_PREPROCESS" in members
         assert "MODEL_INFERENCE" in members
-        assert len(members) == 4
+        assert "MODEL_POST_PROCESS" in members
+        assert len(members) == 5
 
 
 @pytest.mark.unit
@@ -111,7 +117,7 @@ class TestSpan:
         span = Span(
             id_=3,
             parent_id=None,
-            type_=SpanType.PREPROCESS,
+            type_=SpanType.MODEL_PREPROCESS,
             name="Preprocessing",
             start=utc_past,
             end=utc_now,

--- a/tests/unit/models/test_manager.py
+++ b/tests/unit/models/test_manager.py
@@ -380,6 +380,15 @@ class TestGetModel:
         model = mgr.get_model(ModelID.YOLO_V8)
         assert model._path.exists()
 
+    def test_model_kwargs_forwarded_to_constructor(self, path_manager: PathManager) -> None:
+        """model_kwargs are forwarded verbatim to the model constructor."""
+        import pytest
+
+        mgr = ModelManager(path_manager)
+        model = mgr.get_model(ModelID.YOLO_V8, confidence_threshold=0.3)
+        assert isinstance(model, YOLOModel)
+        assert model.confidence_threshold == pytest.approx(0.3)
+
 
 @pytest.mark.unit
 class TestVendoredFlow:

--- a/tests/unit/stages/image/__init__.py
+++ b/tests/unit/stages/image/__init__.py
@@ -1,0 +1,3 @@
+"""Tests for image stages."""
+
+from __future__ import annotations

--- a/tests/unit/stages/image/test_image_detection_stage.py
+++ b/tests/unit/stages/image/test_image_detection_stage.py
@@ -1,0 +1,181 @@
+"""Unit tests for ImageDetectionStage."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from moment_to_action.messages.detection import DetectionMessage
+from moment_to_action.messages.sensor import RawFrameMessage
+from moment_to_action.messages.video import FrameTensorMessage
+from moment_to_action.models.image.detection._base import ImageDetectionModel
+from moment_to_action.models.image.detection._types import BoundingBox, Detection
+from moment_to_action.stages.image._base import ImageStage
+from moment_to_action.stages.image._detection import ImageDetectionStage
+
+
+@pytest.mark.unit
+class TestImageDetectionStage:
+    """Tests for ImageDetectionStage."""
+
+    @pytest.fixture
+    def sample_detection(self) -> Detection:
+        """Return a single Detection for use in mock returns."""
+        return Detection(
+            label="person",
+            confidence=0.9,
+            bbox=BoundingBox(x1=10.0, y1=20.0, x2=100.0, y2=200.0),
+        )
+
+    @pytest.fixture
+    def mock_model(self, sample_detection: Detection) -> MagicMock:
+        """Return a mock ImageDetectionModel with reasonable defaults."""
+        model = MagicMock(spec=ImageDetectionModel)
+        model.prepare.return_value = np.zeros((1, 3, 640, 640), dtype=np.float32)
+        model.run.return_value = [
+            np.zeros((1, 1, 4), dtype=np.float32),
+            np.zeros((1, 1), dtype=np.float32),
+            np.zeros((1, 1), dtype=np.uint8),
+        ]
+        model.post_proc.return_value = [sample_detection]
+        return model
+
+    @pytest.fixture
+    def raw_frame_msg(self) -> RawFrameMessage:
+        """Return a RawFrameMessage with a valid frame."""
+        return RawFrameMessage(
+            frame=np.zeros((480, 640, 3), dtype=np.uint8),
+            timestamp=1234.5,
+            width=640,
+            height=480,
+        )
+
+    @pytest.fixture
+    def dropped_frame_msg(self) -> RawFrameMessage:
+        """Return a RawFrameMessage with frame=None (dropped frame)."""
+        return RawFrameMessage(
+            frame=None,
+            timestamp=1234.5,
+            width=640,
+            height=480,
+        )
+
+    def test_is_subclass_of_image_stage(self) -> None:
+        """ImageDetectionStage must extend ImageStage."""
+        assert issubclass(ImageDetectionStage, ImageStage)
+
+    def test_stage_name(self, mock_model: MagicMock) -> None:
+        """Stage name must be the class name."""
+        stage = ImageDetectionStage(model=mock_model)
+        assert stage.name == "ImageDetectionStage"
+
+    def test_happy_path_returns_detection_message(
+        self,
+        mock_model: MagicMock,
+        raw_frame_msg: RawFrameMessage,
+        sample_detection: Detection,
+    ) -> None:
+        """Valid RawFrameMessage with frame → DetectionMessage with expected detections."""
+        stage = ImageDetectionStage(model=mock_model)
+        result = stage.process(raw_frame_msg)
+
+        assert isinstance(result, DetectionMessage)
+        assert len(result.detections) == 1
+        assert result.detections[0].label == sample_detection.label
+        assert result.detections[0].confidence == pytest.approx(sample_detection.confidence)
+
+    def test_happy_path_calls_model_methods_in_order(
+        self,
+        mock_model: MagicMock,
+        raw_frame_msg: RawFrameMessage,
+    ) -> None:
+        """Verify prepare → run → post_proc call chain is correct."""
+        stage = ImageDetectionStage(model=mock_model)
+        stage.process(raw_frame_msg)
+
+        mock_model.prepare.assert_called_once()
+        assert raw_frame_msg.frame is not None
+        np.testing.assert_array_equal(mock_model.prepare.call_args[0][0], raw_frame_msg.frame)
+        mock_model.run.assert_called_once_with(mock_model.prepare.return_value)
+        mock_model.post_proc.assert_called_once_with(mock_model.run.return_value)
+
+    def test_wrong_message_type_returns_none_and_warns(
+        self, mock_model: MagicMock, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Non-RawFrameMessage input must return None and log a warning."""
+        import logging
+
+        stage = ImageDetectionStage(model=mock_model)
+        wrong_msg = FrameTensorMessage(
+            tensor=np.zeros((1, 3, 640, 640), dtype=np.float32),
+            original_size=(640, 480),
+            timestamp=time.time(),
+        )
+        with caplog.at_level(logging.WARNING):
+            result = stage.process(wrong_msg)
+
+        assert result is None
+        mock_model.prepare.assert_not_called()
+        assert any("RawFrameMessage" in r.message for r in caplog.records)
+
+    def test_dropped_frame_returns_none(
+        self,
+        mock_model: MagicMock,
+        dropped_frame_msg: RawFrameMessage,
+    ) -> None:
+        """RawFrameMessage with frame=None must return None without calling model."""
+        stage = ImageDetectionStage(model=mock_model)
+        result = stage.process(dropped_frame_msg)
+
+        assert result is None
+        mock_model.prepare.assert_not_called()
+
+    def test_empty_detections_returns_detection_message(
+        self,
+        mock_model: MagicMock,
+        raw_frame_msg: RawFrameMessage,
+    ) -> None:
+        """Model returning empty list → DetectionMessage with empty detections list."""
+        mock_model.post_proc.return_value = []
+        stage = ImageDetectionStage(model=mock_model)
+        result = stage.process(raw_frame_msg)
+
+        assert isinstance(result, DetectionMessage)
+        assert result.detections == []
+
+    def test_metrics_spans_recorded(
+        self,
+        mock_model: MagicMock,
+        raw_frame_msg: RawFrameMessage,
+    ) -> None:
+        """Happy path records prepare, run, and post_proc spans in metrics."""
+        from moment_to_action.metrics import MetricsCollector, SpanType
+
+        stage = ImageDetectionStage(model=mock_model)
+        metrics = MetricsCollector(session_id="test_detection_spans")
+        with metrics.start_trace():
+            stage.process(raw_frame_msg, metrics=metrics)
+
+        span_names = {s.name for s in metrics.spans}
+        span_types = {s.type_ for s in metrics.spans}
+        assert "prepare" in span_names
+        assert "run" in span_names
+        assert "post_process" in span_names
+        assert SpanType.MODEL_PREPROCESS in span_types
+        assert SpanType.MODEL_INFERENCE in span_types
+        assert SpanType.MODEL_POST_PROCESS in span_types
+
+    def test_timestamp_preserved(
+        self,
+        mock_model: MagicMock,
+        raw_frame_msg: RawFrameMessage,
+    ) -> None:
+        """Output DetectionMessage.timestamp must match input message timestamp."""
+        stage = ImageDetectionStage(model=mock_model)
+        result = stage.process(raw_frame_msg)
+
+        assert isinstance(result, DetectionMessage)
+        assert result.timestamp == raw_frame_msg.timestamp

--- a/tests/unit/stages/image/test_image_stage.py
+++ b/tests/unit/stages/image/test_image_stage.py
@@ -1,0 +1,22 @@
+"""Unit tests for ImageStage base class."""
+
+from __future__ import annotations
+
+import pytest
+
+from moment_to_action.stages._base import Stage
+from moment_to_action.stages.image._base import ImageStage
+
+
+@pytest.mark.unit
+class TestImageStage:
+    """Tests for ImageStage marker base class."""
+
+    def test_image_stage_is_subclass_of_stage(self) -> None:
+        """ImageStage must extend Stage."""
+        assert issubclass(ImageStage, Stage)
+
+    def test_image_stage_is_abstract(self) -> None:
+        """ImageStage cannot be instantiated directly (no _process implementation)."""
+        with pytest.raises(TypeError):
+            ImageStage()  # type: ignore[abstract]


### PR DESCRIPTION
## Changes
- New `ImageStage` base class for image processing tasks in `stages/image/_base.py`
- `ImageDetectionStage` implementing YOLO-based object detection via `stages/image/_detection.py`
- Updated metrics `SpanType` enum with `IMAGE_STAGE` for metrics collection
- Refactored `BasePreprocessor` for better extensibility
- Updated `stages/__init__.py` to export new image stage classes
- Updated `ModelManager` to support loading YOLO detection models

## Technical Details
- ImageStage follows the standard Stage interface, wrapping _process in metrics/logging
- ImageDetectionStage accepts image messages and outputs DetectionMessage with bounding boxes
- Metrics support added for image processing span tracking
- Scripts (draw_detections, run_yolo_pipeline) updated to use new stage infrastructure

## Verification
- [x] Unit tests
- [x] Integration tests
- [x] Manual testing (stage integration with pipeline)

## Related Issues
Closes #128 
