### PR TITLE
Add HF_TOKEN auth for private HuggingFace repo downloads

### DIFF
--- a/src/moment_to_action/models/_sources/_hugging_face.py
+++ b/src/moment_to_action/models/_sources/_hugging_face.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING
 
 import attrs
@@ -56,6 +57,8 @@ def resolve_hugging_face_source(
     Each file in ``source.files`` is a path relative to ``source.hf_subdir`` (or the repo
     root). Files are stored locally under ``variant_dir`` with the same relative structure.
 
+    Reads ``HF_TOKEN`` from the environment for authenticating against private repositories.
+
     Args:
         source: The HuggingFaceSource to resolve.
         variant_dir: The directory where the model variant files are stored.
@@ -75,6 +78,9 @@ def resolve_hugging_face_source(
         if not download:
             return None
 
+        token = os.environ.get("HF_TOKEN")
+        auth_headers = {"Authorization": f"Bearer {token}"} if token else {}
+
         # Run downloads
         # TODO(#102): This could easily be parallelized if there are multiple files
         for filename in missing_files:
@@ -89,13 +95,15 @@ def resolve_hugging_face_source(
             )
 
             # Get the expected file size for progress tracking
-            metadata = get_hf_file_metadata(url)
+            metadata = get_hf_file_metadata(url, token=token)
             file_size = metadata.size
 
             # Store at the relative path under variant_dir, creating parent dirs as needed
             target_path = variant_dir / filename
             target_path.parent.mkdir(parents=True, exist_ok=True)
-            download_file(url, target_path, show_progress=progress, total=file_size)
+            download_file(
+                url, target_path, show_progress=progress, total=file_size, headers=auth_headers
+            )
 
     # All files should now exist (either they already existed or we just downloaded them)
     for filename in source.files:

--- a/src/moment_to_action/utils/web.py
+++ b/src/moment_to_action/utils/web.py
@@ -52,7 +52,12 @@ def stream_with_progress(
 
 
 def download_file(
-    url: str, dest_path: Path, *, show_progress: bool = True, total: int | None = None
+    url: str,
+    dest_path: Path,
+    *,
+    show_progress: bool = True,
+    total: int | None = None,
+    headers: dict[str, str] | None = None,
 ) -> int:
     """Download a file from a URL to a local path, with optional progress display.
 
@@ -62,6 +67,7 @@ def download_file(
         show_progress: Whether to display download progress using Rich.
         total: Total size of the content in bytes, if known. If None, will attempt to
             infer from the Content-Length header or proceed without a total.
+        headers: Optional HTTP headers to include in the request (e.g. Authorization).
 
     Returns:
         The total number of bytes downloaded.
@@ -70,7 +76,7 @@ def download_file(
         httpx.HTTPError: If the HTTP request fails.
         OSError: If writing to the destination path fails.
     """
-    with httpx.stream("GET", url) as res, dest_path.open("wb") as f:
+    with httpx.stream("GET", url, headers=headers or {}) as res, dest_path.open("wb") as f:
         res.raise_for_status()
 
         # Fast path: just download directly


### PR DESCRIPTION
## Changes
- Read `HF_TOKEN` from env and pass as `Authorization: Bearer` header when downloading HF model files
- Add `headers` param to `download_file` so callers can supply arbitrary request headers

## Technical Details
`hf_hub_url` returns unauthenticated URLs; private repos return 401. Passing the token as an auth header fixes downloads from `llamas-lab/m2a-models`.

## Verification
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing (describe below)
  - [ ]

## Related Issues
Closes #