### PR TITLE
Fix download_file to follow HTTP redirects

### DIFF
--- a/src/moment_to_action/utils/web.py
+++ b/src/moment_to_action/utils/web.py
@@ -76,7 +76,10 @@ def download_file(
         httpx.HTTPError: If the HTTP request fails.
         OSError: If writing to the destination path fails.
     """
-    with httpx.stream("GET", url, headers=headers or {}) as res, dest_path.open("wb") as f:
+    with (
+        httpx.stream("GET", url, headers=headers or {}, follow_redirects=True) as res,
+        dest_path.open("wb") as f,
+    ):
         res.raise_for_status()
 
         # Fast path: just download directly


### PR DESCRIPTION
## Changes
- Add `follow_redirects=True` to `httpx.stream` in `download_file`

## Technical Details
HuggingFace resolves model file URLs via 302 redirects to a CDN (XetHub/S3). `httpx.stream` raises `HTTPStatusError` on 3xx responses by default.

## Verification
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing (describe below)
  - [ ]

## Related Issues
Closes #