### PR TITLE
Set ADSP_LIBRARY_PATH in configure_env to fix HTP skel version mismatch

### DIFF
--- a/src/moment_to_action/qairt/_manager.py
+++ b/src/moment_to_action/qairt/_manager.py
@@ -90,7 +90,7 @@ class QairtSDKManager:
     # --- Environment ---
 
     def configure_env(self) -> None:
-        """Set QAIRT_SDK_ROOT and pre-load libpython so ``import qairt`` resolves correctly.
+        """Set QAIRT_SDK_ROOT, ADSP_LIBRARY_PATH, and pre-load libpython.
 
         QAIRT's native pybind extension (libPyNetRun) lists libpython3.10.so.1.0 as a
         NEEDED dependency. When Python is managed by uv its interpreter is a static
@@ -100,6 +100,12 @@ class QairtSDKManager:
         this registers it in the loaded-libs table under its SONAME, satisfying
         libPyNetRun's dependency check without any filesystem search.
 
+        ADSP_LIBRARY_PATH is prepended with the SDK's ``lib/hexagon-v*/unsigned``
+        directories so that the DSP skel libraries bundled with this SDK version are
+        found before any system-installed skels. A version mismatch between the HTP
+        stub (in the SDK) and the skel (on the device) causes the FastRPC transport
+        CRC check to fail; keeping them in sync prevents that.
+
         Raises:
             RuntimeError: If SDK path is not configured.
         """
@@ -108,6 +114,15 @@ class QairtSDKManager:
             raise RuntimeError(_ERR_NOT_INSTALLED)
         _log.info(f"Setting QAIRT_SDK_ROOT={self._sdk_path}")
         os.environ["QAIRT_SDK_ROOT"] = str(self._sdk_path)
+
+        # Prepend versioned hexagon skel dirs so they shadow any system-installed skels
+        hexagon_dirs = sorted((self._sdk_path / "lib").glob("hexagon-v*/unsigned"))
+        if hexagon_dirs:
+            adsp_paths = ":".join(str(p) for p in hexagon_dirs)
+            existing = os.environ.get("ADSP_LIBRARY_PATH", "")
+            os.environ["ADSP_LIBRARY_PATH"] = f"{adsp_paths}:{existing}" if existing else adsp_paths
+            _log.info(f"Setting ADSP_LIBRARY_PATH={os.environ['ADSP_LIBRARY_PATH']}")
+
         lib_dir = sysconfig.get_config_var("LIBDIR")
         lib_name = sysconfig.get_config_var("INSTSONAME")
         if lib_dir and lib_name:

--- a/tests/unit/qairt/test_manager.py
+++ b/tests/unit/qairt/test_manager.py
@@ -120,6 +120,68 @@ class TestQairtSDKManagerConfigureEnv:
             else:
                 os.environ["QAIRT_SDK_ROOT"] = old
 
+    def test_configure_env_sets_adsp_library_path(self, tmp_path: Path) -> None:
+        """configure_env prepends hexagon-v*/unsigned dirs to ADSP_LIBRARY_PATH."""
+        sdk = tmp_path / "2.45.0.24"
+        v68 = sdk / "lib" / "hexagon-v68" / "unsigned"
+        v73 = sdk / "lib" / "hexagon-v73" / "unsigned"
+        v68.mkdir(parents=True)
+        v73.mkdir(parents=True)
+        mgr = _make_mgr(sdk_path=sdk)
+        old_sdk = os.environ.pop("QAIRT_SDK_ROOT", None)
+        old_adsp = os.environ.pop("ADSP_LIBRARY_PATH", None)
+        try:
+            mgr.configure_env()
+            adsp = os.environ.get("ADSP_LIBRARY_PATH", "")
+            assert str(v68) in adsp
+            assert str(v73) in adsp
+        finally:
+            for key, val in [("QAIRT_SDK_ROOT", old_sdk), ("ADSP_LIBRARY_PATH", old_adsp)]:
+                if val is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = val
+
+    def test_configure_env_prepends_to_existing_adsp_path(self, tmp_path: Path) -> None:
+        """configure_env prepends SDK paths before any pre-existing ADSP_LIBRARY_PATH."""
+        sdk = tmp_path / "2.45.0.24"
+        v68 = sdk / "lib" / "hexagon-v68" / "unsigned"
+        v68.mkdir(parents=True)
+        mgr = _make_mgr(sdk_path=sdk)
+        old_sdk = os.environ.pop("QAIRT_SDK_ROOT", None)
+        old_adsp = os.environ.pop("ADSP_LIBRARY_PATH", None)
+        os.environ["ADSP_LIBRARY_PATH"] = "/system/skel"
+        try:
+            mgr.configure_env()
+            adsp = os.environ["ADSP_LIBRARY_PATH"]
+            assert adsp.startswith(str(v68))
+            assert "/system/skel" in adsp
+            assert adsp.index(str(v68)) < adsp.index("/system/skel")
+        finally:
+            for key, val in [("QAIRT_SDK_ROOT", old_sdk), ("ADSP_LIBRARY_PATH", old_adsp)]:
+                if val is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = val
+
+    def test_configure_env_no_hexagon_dirs_skips_adsp(self, tmp_path: Path) -> None:
+        """configure_env does not set ADSP_LIBRARY_PATH when no hexagon dirs exist."""
+        sdk = tmp_path / "2.45.0.24"
+        sdk.mkdir()
+        (sdk / "lib").mkdir()
+        mgr = _make_mgr(sdk_path=sdk)
+        old_sdk = os.environ.pop("QAIRT_SDK_ROOT", None)
+        old_adsp = os.environ.pop("ADSP_LIBRARY_PATH", None)
+        try:
+            mgr.configure_env()
+            assert "ADSP_LIBRARY_PATH" not in os.environ
+        finally:
+            for key, val in [("QAIRT_SDK_ROOT", old_sdk), ("ADSP_LIBRARY_PATH", old_adsp)]:
+                if val is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = val
+
 
 @pytest.mark.unit
 class TestQairtSDKManagerCheckDeps:


### PR DESCRIPTION
## Changes
- `configure_env()` now globs `lib/hexagon-v*/unsigned` in the SDK and prepends those dirs to `ADSP_LIBRARY_PATH`

## Technical Details
The QNN HTP stub and DSP skel must be the same SDK version. If an older skel sits at `/usr/lib/rfsa/adsp/` (from e.g. QAIRT 2.40.0 installed system-wide), the 2.45.0 stub's FastRPC CRC check fails with `rpc 0x0000000b`. Setting `ADSP_LIBRARY_PATH` to the SDK's hexagon dirs ensures the DSP loader finds the version-matched skel first.

Diagnosed by comparing strace of a working `qnn-net-run` (v2.40.0, system skel = stub) vs failing m2a run (v2.45.0 stub, v2.40.0 system skel).

## Verification
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing (describe below)
  - [ ] Run `m2a model verify` with qcs6490 variant on device

## Related Issues
Closes #