### PR TITLE
Fix ADSP_LIBRARY_PATH: use platform-specific hexagon version table

### DIFF
--- a/src/moment_to_action/qairt/_manager.py
+++ b/src/moment_to_action/qairt/_manager.py
@@ -90,7 +90,7 @@ class QairtSDKManager:
     # --- Environment ---
 
     def configure_env(self) -> None:
-        """Set QAIRT_SDK_ROOT and pre-load libpython so ``import qairt`` resolves correctly.
+        """Set QAIRT_SDK_ROOT, ADSP_LIBRARY_PATH, and pre-load libpython.
 
         QAIRT's native pybind extension (libPyNetRun) lists libpython3.10.so.1.0 as a
         NEEDED dependency. When Python is managed by uv its interpreter is a static
@@ -100,6 +100,12 @@ class QairtSDKManager:
         this registers it in the loaded-libs table under its SONAME, satisfying
         libPyNetRun's dependency check without any filesystem search.
 
+        ADSP_LIBRARY_PATH is prepended with the SDK's ``lib/hexagon-v*/unsigned``
+        directories so that the DSP skel libraries bundled with this SDK version are
+        found before any system-installed skels. A version mismatch between the HTP
+        stub (in the SDK) and the skel (on the device) causes the FastRPC transport
+        CRC check to fail; keeping them in sync prevents that.
+
         Raises:
             RuntimeError: If SDK path is not configured.
         """
@@ -108,6 +114,15 @@ class QairtSDKManager:
             raise RuntimeError(_ERR_NOT_INSTALLED)
         _log.info(f"Setting QAIRT_SDK_ROOT={self._sdk_path}")
         os.environ["QAIRT_SDK_ROOT"] = str(self._sdk_path)
+
+        # Prepend versioned hexagon skel dirs so they shadow any system-installed skels
+        hexagon_dirs = sorted((self._sdk_path / "lib").glob("hexagon-v*/unsigned"))
+        if hexagon_dirs:
+            adsp_paths = ":".join(str(p) for p in hexagon_dirs)
+            existing = os.environ.get("ADSP_LIBRARY_PATH", "")
+            os.environ["ADSP_LIBRARY_PATH"] = f"{adsp_paths}:{existing}" if existing else adsp_paths
+            _log.info(f"Setting ADSP_LIBRARY_PATH={os.environ['ADSP_LIBRARY_PATH']}")
+
         lib_dir = sysconfig.get_config_var("LIBDIR")
         lib_name = sysconfig.get_config_var("INSTSONAME")
         if lib_dir and lib_name:

--- a/src/moment_to_action/qairt/_manager.py
+++ b/src/moment_to_action/qairt/_manager.py
@@ -12,6 +12,7 @@ import sysconfig
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from moment_to_action.hardware._platforms._detection import Platform, detect_platform
 from moment_to_action.qairt._deps import check_system_deps as _check_system_deps
 
 if TYPE_CHECKING:
@@ -28,6 +29,14 @@ _ERR_NOT_INSTALLED = "SDK not installed; run 'm2a qairt install' first"
 _ERR_NOT_INSTALLED_M2A = "SDK not installed via m2a"
 _ERR_FETCH_PATH = "fetch succeeded but SDK path not found under install dir"
 _ERR_ALREADY_INSTALLED = "QAIRT SDK {version} already installed at {path}"
+
+# Maps each Qualcomm platform to the Hexagon DSP version it uses.
+# The FastRPC runtime on these devices does NOT split ADSP_LIBRARY_PATH on ':';
+# it treats the entire value as one literal directory. We therefore set it to
+# exactly the one versioned directory that matches the target SoC.
+_HEXAGON_VERSION: dict[Platform, str] = {
+    Platform.QCS6490: "hexagon-v68",
+}
 
 
 class QairtSDKManager:
@@ -100,11 +109,13 @@ class QairtSDKManager:
         this registers it in the loaded-libs table under its SONAME, satisfying
         libPyNetRun's dependency check without any filesystem search.
 
-        ADSP_LIBRARY_PATH is prepended with the SDK's ``lib/hexagon-v*/unsigned``
-        directories so that the DSP skel libraries bundled with this SDK version are
-        found before any system-installed skels. A version mismatch between the HTP
-        stub (in the SDK) and the skel (on the device) causes the FastRPC transport
-        CRC check to fail; keeping them in sync prevents that.
+        ADSP_LIBRARY_PATH is set to the exact ``lib/hexagon-v{N}/unsigned`` directory
+        for the detected platform (see ``_HEXAGON_VERSION``). FastRPC on these devices
+        treats ADSP_LIBRARY_PATH as a single literal path, not a colon-separated list;
+        using the platform-specific directory ensures the bundled skel shadows any
+        system-installed skel and keeps stub/skel versions in sync, preventing the
+        FastRPC CRC32 handshake failure. Platforms not present in ``_HEXAGON_VERSION``
+        (e.g. x86_64, macOS) skip this step.
 
         Raises:
             RuntimeError: If SDK path is not configured.
@@ -115,13 +126,21 @@ class QairtSDKManager:
         _log.info(f"Setting QAIRT_SDK_ROOT={self._sdk_path}")
         os.environ["QAIRT_SDK_ROOT"] = str(self._sdk_path)
 
-        # Prepend versioned hexagon skel dirs so they shadow any system-installed skels
-        hexagon_dirs = sorted((self._sdk_path / "lib").glob("hexagon-v*/unsigned"))
-        if hexagon_dirs:
-            adsp_paths = ":".join(str(p) for p in hexagon_dirs)
-            existing = os.environ.get("ADSP_LIBRARY_PATH", "")
-            os.environ["ADSP_LIBRARY_PATH"] = f"{adsp_paths}:{existing}" if existing else adsp_paths
-            _log.info(f"Setting ADSP_LIBRARY_PATH={os.environ['ADSP_LIBRARY_PATH']}")
+        # Set ADSP_LIBRARY_PATH to the single hexagon skel dir for this platform.
+        # FastRPC on these devices treats the env var as a literal single path, not
+        # colon-separated, so we must set exactly one directory.
+        try:
+            cur_platform = detect_platform()
+            hexagon_ver = _HEXAGON_VERSION.get(cur_platform)
+        except RuntimeError:
+            hexagon_ver = None
+        if hexagon_ver is not None:
+            skel_dir = self._sdk_path / "lib" / hexagon_ver / "unsigned"
+            if skel_dir.exists():
+                os.environ["ADSP_LIBRARY_PATH"] = str(skel_dir)
+                _log.info(f"Setting ADSP_LIBRARY_PATH={skel_dir}")
+            else:
+                _log.warning(f"Hexagon skel dir not found in SDK: {skel_dir}")
 
         lib_dir = sysconfig.get_config_var("LIBDIR")
         lib_name = sysconfig.get_config_var("INSTSONAME")

--- a/tests/unit/qairt/test_manager.py
+++ b/tests/unit/qairt/test_manager.py
@@ -120,6 +120,68 @@ class TestQairtSDKManagerConfigureEnv:
             else:
                 os.environ["QAIRT_SDK_ROOT"] = old
 
+    def test_configure_env_sets_adsp_library_path(self, tmp_path: Path) -> None:
+        """configure_env prepends hexagon-v*/unsigned dirs to ADSP_LIBRARY_PATH."""
+        sdk = tmp_path / "2.45.0.24"
+        v68 = sdk / "lib" / "hexagon-v68" / "unsigned"
+        v73 = sdk / "lib" / "hexagon-v73" / "unsigned"
+        v68.mkdir(parents=True)
+        v73.mkdir(parents=True)
+        mgr = _make_mgr(sdk_path=sdk)
+        old_sdk = os.environ.pop("QAIRT_SDK_ROOT", None)
+        old_adsp = os.environ.pop("ADSP_LIBRARY_PATH", None)
+        try:
+            mgr.configure_env()
+            adsp = os.environ.get("ADSP_LIBRARY_PATH", "")
+            assert str(v68) in adsp
+            assert str(v73) in adsp
+        finally:
+            for key, val in [("QAIRT_SDK_ROOT", old_sdk), ("ADSP_LIBRARY_PATH", old_adsp)]:
+                if val is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = val
+
+    def test_configure_env_prepends_to_existing_adsp_path(self, tmp_path: Path) -> None:
+        """configure_env prepends SDK paths before any pre-existing ADSP_LIBRARY_PATH."""
+        sdk = tmp_path / "2.45.0.24"
+        v68 = sdk / "lib" / "hexagon-v68" / "unsigned"
+        v68.mkdir(parents=True)
+        mgr = _make_mgr(sdk_path=sdk)
+        old_sdk = os.environ.pop("QAIRT_SDK_ROOT", None)
+        old_adsp = os.environ.pop("ADSP_LIBRARY_PATH", None)
+        os.environ["ADSP_LIBRARY_PATH"] = "/system/skel"
+        try:
+            mgr.configure_env()
+            adsp = os.environ["ADSP_LIBRARY_PATH"]
+            assert adsp.startswith(str(v68))
+            assert "/system/skel" in adsp
+            assert adsp.index(str(v68)) < adsp.index("/system/skel")
+        finally:
+            for key, val in [("QAIRT_SDK_ROOT", old_sdk), ("ADSP_LIBRARY_PATH", old_adsp)]:
+                if val is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = val
+
+    def test_configure_env_no_hexagon_dirs_skips_adsp(self, tmp_path: Path) -> None:
+        """configure_env does not set ADSP_LIBRARY_PATH when no hexagon dirs exist."""
+        sdk = tmp_path / "2.45.0.24"
+        sdk.mkdir()
+        (sdk / "lib").mkdir()
+        mgr = _make_mgr(sdk_path=sdk)
+        old_sdk = os.environ.pop("QAIRT_SDK_ROOT", None)
+        old_adsp = os.environ.pop("ADSP_LIBRARY_PATH", None)
+        try:
+            mgr.configure_env()
+            assert "ADSP_LIBRARY_PATH" not in os.environ
+        finally:
+            for key, val in [("QAIRT_SDK_ROOT", old_sdk), ("ADSP_LIBRARY_PATH", old_adsp)]:
+                if val is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = val
+
 
 @pytest.mark.unit
 class TestQairtSDKManagerCheckDeps:

--- a/tests/unit/qairt/test_manager.py
+++ b/tests/unit/qairt/test_manager.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from moment_to_action.config import AppConfig
+from moment_to_action.hardware._platforms._detection import Platform
 from moment_to_action.qairt._manager import QairtSDKManager
 
 
@@ -121,20 +122,20 @@ class TestQairtSDKManagerConfigureEnv:
                 os.environ["QAIRT_SDK_ROOT"] = old
 
     def test_configure_env_sets_adsp_library_path(self, tmp_path: Path) -> None:
-        """configure_env prepends hexagon-v*/unsigned dirs to ADSP_LIBRARY_PATH."""
+        """configure_env sets ADSP_LIBRARY_PATH to the platform-specific hexagon dir."""
         sdk = tmp_path / "2.45.0.24"
         v68 = sdk / "lib" / "hexagon-v68" / "unsigned"
-        v73 = sdk / "lib" / "hexagon-v73" / "unsigned"
         v68.mkdir(parents=True)
-        v73.mkdir(parents=True)
         mgr = _make_mgr(sdk_path=sdk)
         old_sdk = os.environ.pop("QAIRT_SDK_ROOT", None)
         old_adsp = os.environ.pop("ADSP_LIBRARY_PATH", None)
         try:
-            mgr.configure_env()
-            adsp = os.environ.get("ADSP_LIBRARY_PATH", "")
-            assert str(v68) in adsp
-            assert str(v73) in adsp
+            with patch(
+                "moment_to_action.qairt._manager.detect_platform",
+                return_value=Platform.QCS6490,
+            ):
+                mgr.configure_env()
+            assert os.environ.get("ADSP_LIBRARY_PATH") == str(v68)
         finally:
             for key, val in [("QAIRT_SDK_ROOT", old_sdk), ("ADSP_LIBRARY_PATH", old_adsp)]:
                 if val is None:
@@ -142,21 +143,21 @@ class TestQairtSDKManagerConfigureEnv:
                 else:
                     os.environ[key] = val
 
-    def test_configure_env_prepends_to_existing_adsp_path(self, tmp_path: Path) -> None:
-        """configure_env prepends SDK paths before any pre-existing ADSP_LIBRARY_PATH."""
+    def test_configure_env_skips_adsp_for_non_qualcomm_platform(self, tmp_path: Path) -> None:
+        """configure_env does not set ADSP_LIBRARY_PATH on platforms without a hexagon version."""
         sdk = tmp_path / "2.45.0.24"
         v68 = sdk / "lib" / "hexagon-v68" / "unsigned"
         v68.mkdir(parents=True)
         mgr = _make_mgr(sdk_path=sdk)
         old_sdk = os.environ.pop("QAIRT_SDK_ROOT", None)
         old_adsp = os.environ.pop("ADSP_LIBRARY_PATH", None)
-        os.environ["ADSP_LIBRARY_PATH"] = "/system/skel"
         try:
-            mgr.configure_env()
-            adsp = os.environ["ADSP_LIBRARY_PATH"]
-            assert adsp.startswith(str(v68))
-            assert "/system/skel" in adsp
-            assert adsp.index(str(v68)) < adsp.index("/system/skel")
+            with patch(
+                "moment_to_action.qairt._manager.detect_platform",
+                return_value=Platform.X86_64,
+            ):
+                mgr.configure_env()
+            assert "ADSP_LIBRARY_PATH" not in os.environ
         finally:
             for key, val in [("QAIRT_SDK_ROOT", old_sdk), ("ADSP_LIBRARY_PATH", old_adsp)]:
                 if val is None:
@@ -164,16 +165,43 @@ class TestQairtSDKManagerConfigureEnv:
                 else:
                     os.environ[key] = val
 
-    def test_configure_env_no_hexagon_dirs_skips_adsp(self, tmp_path: Path) -> None:
-        """configure_env does not set ADSP_LIBRARY_PATH when no hexagon dirs exist."""
+    def test_configure_env_skips_adsp_when_skel_dir_missing(self, tmp_path: Path) -> None:
+        """configure_env skips ADSP_LIBRARY_PATH if the hexagon dir isn't in the SDK."""
         sdk = tmp_path / "2.45.0.24"
         sdk.mkdir()
         (sdk / "lib").mkdir()
+        # No hexagon-v68/unsigned dir created
         mgr = _make_mgr(sdk_path=sdk)
         old_sdk = os.environ.pop("QAIRT_SDK_ROOT", None)
         old_adsp = os.environ.pop("ADSP_LIBRARY_PATH", None)
         try:
-            mgr.configure_env()
+            with patch(
+                "moment_to_action.qairt._manager.detect_platform",
+                return_value=Platform.QCS6490,
+            ):
+                mgr.configure_env()
+            assert "ADSP_LIBRARY_PATH" not in os.environ
+        finally:
+            for key, val in [("QAIRT_SDK_ROOT", old_sdk), ("ADSP_LIBRARY_PATH", old_adsp)]:
+                if val is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = val
+
+    def test_configure_env_skips_adsp_when_detect_platform_fails(self, tmp_path: Path) -> None:
+        """configure_env skips ADSP_LIBRARY_PATH if platform detection raises."""
+        sdk = tmp_path / "2.45.0.24"
+        v68 = sdk / "lib" / "hexagon-v68" / "unsigned"
+        v68.mkdir(parents=True)
+        mgr = _make_mgr(sdk_path=sdk)
+        old_sdk = os.environ.pop("QAIRT_SDK_ROOT", None)
+        old_adsp = os.environ.pop("ADSP_LIBRARY_PATH", None)
+        try:
+            with patch(
+                "moment_to_action.qairt._manager.detect_platform",
+                side_effect=RuntimeError("unknown platform"),
+            ):
+                mgr.configure_env()
             assert "ADSP_LIBRARY_PATH" not in os.environ
         finally:
             for key, val in [("QAIRT_SDK_ROOT", old_sdk), ("ADSP_LIBRARY_PATH", old_adsp)]:


### PR DESCRIPTION
## Summary

- FastRPC on QCS6490 Ubuntu treats `ADSP_LIBRARY_PATH` as a single literal path, not colon-separated. The previous colon-join approach caused the entire joined string to be used as one path component, so `libQnnHtpV68Skel.so` was never found and the DSP loader fell back to the stale system skel at `/usr/lib/rfsa/adsp/` (QAIRT 2.40.0 vs stub 2.45.0 → CRC32 handshake failure).
- Add `_HEXAGON_VERSION: dict[Platform, str]` table mapping each Qualcomm SoC to its Hexagon DSP version (`QCS6490 → hexagon-v68`).
- `configure_env()` now calls `detect_platform()`, looks up the version, and sets `ADSP_LIBRARY_PATH` to exactly that one directory. Non-Qualcomm platforms and unknown platforms skip the step entirely.

## Test plan

- [ ] `just lint && just test` pass (984 passed, 100% coverage)
- [ ] `test_configure_env_sets_adsp_library_path` — QCS6490 → v68 dir set
- [ ] `test_configure_env_skips_adsp_for_non_qualcomm_platform` — X86_64 → no ADSP set
- [ ] `test_configure_env_skips_adsp_when_skel_dir_missing` — dir absent → no ADSP set
- [ ] `test_configure_env_skips_adsp_when_detect_platform_fails` — RuntimeError → no ADSP set