### PR TITLE
fix(scripts): fix pipefail crash and add /opt/llm install step

### DIFF
--- a/scripts/build_opencl_llamacpp.sh
+++ b/scripts/build_opencl_llamacpp.sh
@@ -171,22 +171,22 @@ ok "llama.cpp built"
 # ---------------------------------------------------------------------------
 # 6. Install binaries to $INSTALL_PREFIX
 # ---------------------------------------------------------------------------
-log "Installing binaries to $INSTALL_PREFIX/bin"
+log "Installing binaries to $INSTALL_PREFIX"
 BIN_SRC="$LLAMA_DIR/build/bin"
 if [[ ! -d "$BIN_SRC" ]]; then
     die "Expected bin dir not found: $BIN_SRC"
 fi
 
-sudo mkdir -p "$INSTALL_PREFIX/bin"
-sudo cp "$BIN_SRC"/llama-* "$INSTALL_PREFIX/bin/"
-ok "Copied $(ls "$BIN_SRC"/llama-* | wc -l) binaries → $INSTALL_PREFIX/bin"
+sudo mkdir -p "$INSTALL_PREFIX"
+sudo cp "$BIN_SRC"/llama-* "$INSTALL_PREFIX/"
+ok "Copied $(ls "$BIN_SRC"/llama-* | wc -l) binaries → $INSTALL_PREFIX"
 
 # ---------------------------------------------------------------------------
 # Done
 # ---------------------------------------------------------------------------
 echo ""
 echo -e "${GREEN}${BOLD}All done.${RESET}"
-echo -e "  Binaries in: ${CYAN}$INSTALL_PREFIX/bin/${RESET}"
-if [[ ":$PATH:" != *":$INSTALL_PREFIX/bin:"* ]]; then
-    echo -e "  ${YELLOW}Note:${RESET} Add to PATH: export PATH=\"$INSTALL_PREFIX/bin:\$PATH\""
+echo -e "  Binaries in: ${CYAN}$INSTALL_PREFIX/${RESET}"
+if [[ ":$PATH:" != *":$INSTALL_PREFIX:"* ]]; then
+    echo -e "  ${YELLOW}Note:${RESET} Add to PATH: export PATH=\"$INSTALL_PREFIX:\$PATH\""
 fi

--- a/scripts/build_opencl_llamacpp.sh
+++ b/scripts/build_opencl_llamacpp.sh
@@ -48,7 +48,9 @@ cmake_build_install() {
     local src="$1"; shift
     local build_dir="$src/build"
     mkdir -p "$build_dir"
-    cmake -S "$src" -B "$build_dir" -G Ninja "$@" 2>&1 | grep -v "^--"
+    # grep -v exits 1 when all lines match (cmake output is almost entirely "-- ..." lines)
+    # so suppress grep's exit code; pipefail would otherwise kill the script
+    cmake -S "$src" -B "$build_dir" -G Ninja "$@" 2>&1 | grep -v "^--" || true
     cmake --build "$build_dir" --target install -- -j"$JOBS"
 }
 
@@ -162,7 +164,7 @@ mkdir -p "$LLAMA_DIR/build"
 cmake -S "$LLAMA_DIR" -B "$LLAMA_DIR/build" -G Ninja \
     -DCMAKE_BUILD_TYPE=Release \
     -DBUILD_SHARED_LIBS=OFF \
-    -DGGML_OPENCL=ON 2>&1 | grep -v "^--"
+    -DGGML_OPENCL=ON 2>&1 | grep -v "^--" || true
 ninja -C "$LLAMA_DIR/build" -j"$JOBS"
 ok "llama.cpp built"
 


### PR DESCRIPTION
## Summary
- `grep -v "^--"` exits 1 when all cmake configure output lines start with `--`; `pipefail` killed the script after OpenCL-Headers build
- Fix: add `|| true` to both cmake configure pipes
- Generalize hardcoded paths (env-var overrides for `DEV_DIR`, `OPENCL_PREFIX`, `INSTALL_PREFIX`, etc.)
- Add system package check with optional `apt-get install`
- Copy llama.cpp binaries to `$INSTALL_PREFIX/bin` (default `/opt/llm/bin`) after build

## Test plan
- [ ] Run on target aarch64 machine, verify all three build stages complete
- [ ] Confirm binaries present in `/opt/llm/bin/`
- [ ] Re-run script (clone-or-update path) — no crash on already-cloned repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)